### PR TITLE
Cleanup dev override

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,14 +102,15 @@ jobs:
           path: ./build_artifacts
 
       - name: Unpack provider in ./dist
+        id: unpack
         shell: bash
         run: |
           mkdir -p dist
           echo "ZIP_FILENAME=$(\
                   find ./build_artifacts -name *.zip -print | head -n1 \
                 )" >> "$GITHUB_OUTPUT"
-          echo Running: "unzip ${{ steps.download.outputs.ZIP_FILENAME }} -d ./dist/"
-          unzip ${{ steps.download.outputs.ZIP_FILENAME }} -d ./dist/
+          echo Running: "unzip ${{ steps.unpack.outputs.ZIP_FILENAME }} -d ./dist/"
+          unzip ${{ steps.unpack.outputs.ZIP_FILENAME }} -d ./dist/
 
       - name: Install local dev override
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,11 +106,10 @@ jobs:
         shell: bash
         run: |
           mkdir -p dist
-          echo "ZIP_FILENAME=$(\
-                  find ./build_artifacts -name *.zip -print | head -n1 \
-                )" >> "$GITHUB_OUTPUT"
-          echo Running: "unzip ${{ steps.unpack.outputs.ZIP_FILENAME }} -d ./dist/"
-          unzip ${{ steps.unpack.outputs.ZIP_FILENAME }} -d ./dist/
+          ZIP_FILENAME=$(find ./build_artifacts -name '*.zip' -print -quit)
+          echo "ZIP_FILENAME=${ZIP_FILENAME}" >> "$GITHUB_OUTPUT"
+          echo "Running: unzip '${ZIP_FILENAME}' -d ./dist/"
+          unzip "${ZIP_FILENAME}" -d ./dist/
 
       - name: Install local dev override
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,10 +108,11 @@ jobs:
           mkdir -p dist
           ZIP_FILENAME=$(find ./build_artifacts -type f -name '*.zip' -print -quit)
           mv "$ZIP_FILENAME" ./dist/
+          ls -la ./dist
 
       - name: Install local dev override
         run: |
-          make install
+          make install VERSION=v0.0.1
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,15 +101,13 @@ jobs:
           name: ${{ needs.build.outputs.zip_archive_name }}
           path: ./build_artifacts
 
-      - name: Unpack provider in ./dist
+      - name: Install build_artifact in ./dist
         id: unpack
         shell: bash
         run: |
           mkdir -p dist
           ZIP_FILENAME=$(find ./build_artifacts -type f -name '*.zip' -print -quit)
-          echo "ZIP_FILENAME=${ZIP_FILENAME}" >> "$GITHUB_OUTPUT"
-          echo "Running: unzip '${ZIP_FILENAME}' -d ./dist/"
-          unzip "${ZIP_FILENAME}" -d ./dist/
+          mv "$ZIP_FILENAME" ./dist/
 
       - name: Install local dev override
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,17 +101,18 @@ jobs:
           name: ${{ needs.build.outputs.zip_archive_name }}
           path: ./build_artifacts
 
-      - name: Flatten artifacts into ./dist
+      - name: Unpack provider in ./dist
         shell: bash
         run: |
           mkdir -p dist
-          for d in build_artifacts/*; do
-            mv "$d"/*.zip dist/
-          done
+          echo "ZIP_FILENAME=$(\
+                  find ./build_artifacts -name *.zip -print | head -n1 \
+                )" >> "$GITHUB_OUTPUT"
+          unzip -o ${{ steps.download.outputs.ZIP_FILENAME }} -d ./dist/
 
-      - name: Install local provider
+      - name: Install local dev override
         run: |
-          make install2 VERSION=v0.0.1
+          make install
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,6 @@ jobs:
           mkdir -p dist
           ZIP_FILENAME=$(find ./build_artifacts -type f -name '*.zip' -print -quit)
           mv "$ZIP_FILENAME" ./dist/
-          ls -la ./dist
 
       - name: Install local dev override
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p dist
-          ZIP_FILENAME=$(find ./build_artifacts -name '*.zip' -print -quit)
+          ZIP_FILENAME=$(find ./build_artifacts -type f -name '*.zip' -print -quit)
           echo "ZIP_FILENAME=${ZIP_FILENAME}" >> "$GITHUB_OUTPUT"
           echo "Running: unzip '${ZIP_FILENAME}' -d ./dist/"
           unzip "${ZIP_FILENAME}" -d ./dist/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,6 +108,7 @@ jobs:
           echo "ZIP_FILENAME=$(\
                   find ./build_artifacts -name *.zip -print | head -n1 \
                 )" >> "$GITHUB_OUTPUT"
+          echo Running: "unzip ${{ steps.download.outputs.ZIP_FILENAME }} -d ./dist/"
           unzip ${{ steps.download.outputs.ZIP_FILENAME }} -d ./dist/
 
       - name: Install local dev override

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,7 @@ jobs:
           echo "ZIP_FILENAME=$(\
                   find ./build_artifacts -name *.zip -print | head -n1 \
                 )" >> "$GITHUB_OUTPUT"
-          unzip -o ${{ steps.download.outputs.ZIP_FILENAME }} -d ./dist/
+          unzip ${{ steps.download.outputs.ZIP_FILENAME }} -d ./dist/
 
       - name: Install local dev override
         run: |

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,8 @@ package: build
 
 install:
 	@mkdir -p ~/.terraform.d/plugins
-	unzip -o $(BUILD_DIR)/$(ZIP_ARCHIVE_NAME) -d ~/.terraform.d/plugins
-#	@cp $(BUILD_DIR)/$(BINARY_NAME) ~/.terraform.d/plugins/$(DEV_BINARY_NAME)
+	unzip -o $(BUILD_DIR)/$(ZIP_ARCHIVE_NAME) -d $(BUILD_DIR)
+	@cp $(BUILD_DIR)/$(BINARY_NAME) ~/.terraform.d/plugins/$(NAME)
 
 test: prepare
 	go test -v -parallel 4 -tags unit -coverprofile=$(BUILD_DIR)/cover.out ./...
@@ -61,7 +61,7 @@ testacc: prepare
 clean:
 	@echo Cleaning up build dir and installed binaries...
 	@rm -rf $(BUILD_DIR)
-	@rm -rf ~/.terraform.d/plugins/$(BINARY_NAME)
+	@rm -rf ~/.terraform.d/plugins/$(NAME)
 
 manifest: prepare
 	@./generate-manifest.sh $(BUILD_DIR) $(VERSION) $(PROVIDER)

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,8 @@ package: build
 
 install:
 	@mkdir -p ~/.terraform.d/plugins
-	@cp $(BUILD_DIR)/$(BINARY_NAME) ~/.terraform.d/plugins/$(DEV_BINARY_NAME)
+	unzip -o $(BUILD_DIR)/$(ZIP_ARCHIVE_NAME) -d ~/.terraform.d/plugins
+#	@cp $(BUILD_DIR)/$(BINARY_NAME) ~/.terraform.d/plugins/$(DEV_BINARY_NAME)
 
 test: prepare
 	go test -v -parallel 4 -tags unit -coverprofile=$(BUILD_DIR)/cover.out ./...
@@ -60,7 +61,7 @@ testacc: prepare
 clean:
 	@echo Cleaning up build dir and installed binaries...
 	@rm -rf $(BUILD_DIR)
-	@rm -rf ~/.terraform.d/plugins/$(DEV_BINARY_NAME)
+	@rm -rf ~/.terraform.d/plugins/$(BINARY_NAME)
 
 manifest: prepare
 	@./generate-manifest.sh $(BUILD_DIR) $(VERSION) $(PROVIDER)

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,7 @@ BUILD_DIR    := $(ROOT_DIR)/dist
 
 # Version information
 _GIT_VERSION := $(shell git describe --tags --always)
-_VERSION_FROM_GIT := $(shell \
-	if echo "$(_GIT_VERSION)" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$$'; then \
-		echo "$(_GIT_VERSION)"; \
-	else \
-		echo "v0.0.1-$(_GIT_VERSION)"; \
-	fi)
-VERSION      ?= $(_VERSION_FROM_GIT)
+VERSION      ?= $(shell if echo "$(_GIT_VERSION)" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$$'; then echo "$(_GIT_VERSION)"; else echo "v0.0.1-$(_GIT_VERSION)"; fi)
 VERSION_NO_V := $(patsubst v%,%,$(VERSION))
 GITSHA       := $(shell git rev-parse --short HEAD)
 
@@ -28,7 +22,8 @@ GIT_REVISION       :=$(shell git rev-list -1 HEAD)
 GIT_REVISION_DIRTY :=$(shell (git diff-index --quiet HEAD -- . && git diff --staged --quiet -- .) || echo "-dirty")
 
 # Binary and archive names
-BINARY_NAME ?= $(NAME)_v$(VERSION_NO_V)
+BINARY_NAME      ?= $(NAME)_v$(VERSION_NO_V)
+DEV_BINARY_NAME  ?= $(NAME)
 ZIP_ARCHIVE_NAME ?= $(NAME)_$(VERSION_NO_V)_$(OS_ARCH).zip
 
 # Build flags
@@ -52,12 +47,8 @@ package: build
 	@zip -j $(BUILD_DIR)/$(ZIP_ARCHIVE_NAME) $(BUILD_DIR)/$(BINARY_NAME)
 
 install:
-	@mkdir -p ~/.terraform.d/plugins/$(DOMAIN)/$(COMPANY)/$(PROVIDER)
-	@unzip -o $(BUILD_DIR)/$(ZIP_ARCHIVE_NAME) -d ~/.terraform.d/plugins/$(DOMAIN)/$(COMPANY)/$(PROVIDER)
-
-install2: install
-	@mkdir -p ~/.terraform.d/plugins/$(DOMAIN)/$(COMPANY)/$(PROVIDER)/$(VERSION_NO_V)/$(OS_ARCH)
-	@cp ~/.terraform.d/plugins/$(DOMAIN)/$(COMPANY)/$(PROVIDER)/$(BINARY_NAME) ~/.terraform.d/plugins/$(DOMAIN)/$(COMPANY)/$(PROVIDER)/$(VERSION_NO_V)/$(OS_ARCH)/$(NAME)
+	@mkdir -p ~/.terraform.d/plugins
+	@cp $(BUILD_DIR)/$(BINARY_NAME) ~/.terraform.d/plugins/$(DEV_BINARY_NAME)
 
 test: prepare
 	go test -v -parallel 4 -tags unit -coverprofile=$(BUILD_DIR)/cover.out ./...
@@ -67,8 +58,9 @@ testacc: prepare
 	go test -v -tags integration -coverprofile=$(BUILD_DIR)/cover.out ./...
 
 clean:
-	rm -rf $(BUILD_DIR)
-	rm -rf ~/.terraform.d/plugins/$(DOMAIN)/$(COMPANY)/$(PROVIDER)
+	@echo Cleaning up build dir and installed binaries...
+	@rm -rf $(BUILD_DIR)
+	@rm -rf ~/.terraform.d/plugins/$(DEV_BINARY_NAME)
 
 manifest: prepare
 	@./generate-manifest.sh $(BUILD_DIR) $(VERSION) $(PROVIDER)

--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ make build
 ```hcl
 provider_installation {
   dev_overrides {
-    "pexip/pexip" = "/path/to/your/terraform-provider-pexip/dist"
+    "pexip/pexip" = "<home dir>/.terraform.d/plugins"
   }
   direct {}
 }

--- a/example/gcp/gcp-infinity-manager/provider.tf
+++ b/example/gcp/gcp-infinity-manager/provider.tf
@@ -8,8 +8,7 @@ terraform {
   required_version = ">= 1.0"
   required_providers {
     pexip = {
-      source  = "pexip.com/pexip/pexip"
-      version = "0.0.1"
+      source  = "pexip/pexip"
     }
     google = {
       source  = "hashicorp/google"

--- a/example/gcp/gcp-infinity-manager/provider.tf
+++ b/example/gcp/gcp-infinity-manager/provider.tf
@@ -8,7 +8,7 @@ terraform {
   required_version = ">= 1.0"
   required_providers {
     pexip = {
-      source  = "pexip/pexip"
+      source = "pexip/pexip"
     }
     google = {
       source  = "hashicorp/google"

--- a/example/gcp/gcp-infinity-node/provider.tf
+++ b/example/gcp/gcp-infinity-node/provider.tf
@@ -8,8 +8,7 @@ terraform {
   required_version = ">= 1.0"
   required_providers {
     pexip = {
-      source  = "pexip.com/pexip/pexip"
-      version = "0.0.1"
+      source  = "pexip/pexip"
     }
     google = {
       source  = "hashicorp/google"

--- a/example/gcp/gcp-infinity-node/provider.tf
+++ b/example/gcp/gcp-infinity-node/provider.tf
@@ -8,7 +8,7 @@ terraform {
   required_version = ">= 1.0"
   required_providers {
     pexip = {
-      source  = "pexip/pexip"
+      source = "pexip/pexip"
     }
     google = {
       source  = "hashicorp/google"

--- a/example/gcp/provider.tf
+++ b/example/gcp/provider.tf
@@ -7,8 +7,8 @@
 terraform {
   required_providers {
     pexip = {
-      source  = "pexip.com/pexip/pexip"
-      version = "0.0.1"
+      source  = "pexip/pexip"
+      version = ">= 0.9.0"
     }
     google = {
       source  = "hashicorp/google"

--- a/example/openstack/openstack-infinity-manager/provider.tf
+++ b/example/openstack/openstack-infinity-manager/provider.tf
@@ -8,7 +8,7 @@ terraform {
   required_version = ">= 1.0"
   required_providers {
     pexip = {
-      source  = "pexip.com/pexip/pexip"
+      source  = "pexip/pexip"
       version = "0.0.1"
     }
     openstack = {

--- a/example/openstack/openstack-infinity-node/provider.tf
+++ b/example/openstack/openstack-infinity-node/provider.tf
@@ -8,7 +8,7 @@ terraform {
   required_version = ">= 1.0"
   required_providers {
     pexip = {
-      source  = "pexip.com/pexip/pexip"
+      source  = "pexip/pexip"
       version = "0.0.1"
     }
     openstack = {

--- a/example/openstack/provider.tf
+++ b/example/openstack/provider.tf
@@ -7,7 +7,7 @@
 terraform {
   required_providers {
     pexip = {
-      source  = "pexip.com/pexip/pexip"
+      source  = "pexip/pexip"
       version = "0.0.1"
     }
     openstack = {

--- a/main.go
+++ b/main.go
@@ -8,14 +8,13 @@ package main
 
 import (
 	"context"
+	"log"
 	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 
-	"github.com/pexip/terraform-provider-pexip/internal/log"
 	pexipProvider "github.com/pexip/terraform-provider-pexip/internal/provider"
-	"github.com/pexip/terraform-provider-pexip/internal/version"
 )
 
 func createProvider() func() provider.Provider {
@@ -23,21 +22,11 @@ func createProvider() func() provider.Provider {
 }
 
 func main() {
-	ctx := context.Background()
-	logger := log.NewTerraformLogger()
-	path, err := os.Getwd()
-	if err != nil {
-		logger.Errorf(ctx, "failed to initialize provider: %s", err.Error())
-	}
-
-	logger.Infof(ctx, "%s", version.Version().String())
-	logger.Infof(ctx, "%s", path)
-
-	err = providerserver.Serve(ctx, createProvider(), providerserver.ServeOpts{
-		Address: "pexip.com/pexip/pexip",
+	err := providerserver.Serve(context.Background(), createProvider(), providerserver.ServeOpts{
+		Address: "registry.terraform.io/pexip/pexip",
 	})
 	if err != nil {
-		logger.Errorf(ctx, "failed to serve provider: %s", err.Error())
+		log.Printf("failed to serve provider: %s", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
# Description

This PR cleans up the development override configuration by removing the custom domain setup and transitioning to standard Terraform registry conventions. The changes simplify the provider development workflow by using the official registry format and updating the installation process to use a standard plugin directory.

- Remove custom logging and version display from main.go and switch to standard Go logging
- Update provider source from custom "pexip.com/pexip/pexip" to official "registry.terraform.io/pexip/pexip" format
- Simplify Makefile installation process to use standard ~/.terraform.d/plugins directory

## Change management

See project labels for change classification and risk.

Change reason?

Please describe the reason for the change here.

Change rollback plan?

If nothing else is specified, the change will be rolled back by reverting the commit.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration