### PR TITLE
Update go-infinity-sdk to v38.0.21 and enhance webapp branding resour…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.29.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
-	github.com/pexip/go-infinity-sdk/v38 v38.0.20
+	github.com/pexip/go-infinity-sdk/v38 v38.0.21
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.45.0
 )

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
-github.com/pexip/go-infinity-sdk/v38 v38.0.20 h1:d2lcN7Q96kQ3H6I9qhymMWX0CWF3MMROl0uxX1K9+NA=
-github.com/pexip/go-infinity-sdk/v38 v38.0.20/go.mod h1:gtMzH/Mhk51u1oNkmM38cgQUV9NJc5pguq3gj3hABxk=
+github.com/pexip/go-infinity-sdk/v38 v38.0.21 h1:lPz01tqfjJXyn2vKg1J2szDdJFxRNUB+4XJTDbDob6U=
+github.com/pexip/go-infinity-sdk/v38 v38.0.21/go.mod h1:gtMzH/Mhk51u1oNkmM38cgQUV9NJc5pguq3gj3hABxk=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=
 github.com/pjbgf/sha1cd v0.3.2/go.mod h1:zQWigSxVmsHEZow5qaLtPYxpcKMMQpa09ixqBxuCS6A=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/provider/resource_infinity_webapp_alias.go
+++ b/internal/provider/resource_infinity_webapp_alias.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -81,10 +82,12 @@ func (r *InfinityWebappAliasResource) Schema(ctx context.Context, req resource.S
 			},
 			"description": schema.StringAttribute{
 				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(""),
 				Validators: []validator.String{
-					stringvalidator.LengthAtMost(500),
+					stringvalidator.LengthAtMost(250),
 				},
-				MarkdownDescription: "Description of the webapp alias. Maximum length: 500 characters.",
+				MarkdownDescription: "Description of the webapp alias. Maximum length: 250 characters.",
 			},
 			"webapp_type": schema.StringAttribute{
 				Required: true,
@@ -194,14 +197,16 @@ func (r *InfinityWebappAliasResource) read(ctx context.Context, resourceID int) 
 	data.IsEnabled = types.BoolValue(srv.IsEnabled)
 
 	// Handle optional pointer fields
+	// Convert bundle from SDK to Terraform format
 	if srv.Bundle != nil {
-		data.Bundle = types.StringValue(*srv.Bundle)
+		data.Bundle = types.StringValue(fmt.Sprintf("/api/admin/configuration/v1/software_bundle_revision/%d/", srv.Bundle.ID))
 	} else {
 		data.Bundle = types.StringNull()
 	}
 
+	// Convert branding from SDK to Terraform format
 	if srv.Branding != nil {
-		data.Branding = types.StringValue(*srv.Branding)
+		data.Branding = types.StringValue(fmt.Sprintf("/api/admin/configuration/v1/webapp_branding/%s/", srv.Branding.UUID))
 	} else {
 		data.Branding = types.StringNull()
 	}

--- a/internal/provider/resource_infinity_webapp_alias_test.go
+++ b/internal/provider/resource_infinity_webapp_alias_test.go
@@ -68,12 +68,9 @@ func TestInfinityWebappAlias(t *testing.T) {
 		if updateReq.IsEnabled != nil {
 			mockState.IsEnabled = *updateReq.IsEnabled
 		}
-		if updateReq.Bundle != nil {
-			mockState.Bundle = updateReq.Bundle
-		}
-		if updateReq.Branding != nil {
-			mockState.Branding = updateReq.Branding
-		}
+		// Note: Bundle and Branding are sent as string URIs in requests,
+		// but returned as objects in responses. We don't update them in the mock
+		// since the test doesn't use these fields.
 
 		// Return updated state
 		*webapp_alias = *mockState

--- a/internal/provider/resource_infinity_webapp_branding.go
+++ b/internal/provider/resource_infinity_webapp_branding.go
@@ -34,6 +34,7 @@ type InfinityWebappBrandingResource struct {
 }
 
 type InfinityWebappBrandingResourceModel struct {
+	ID           types.String `tfsdk:"id"`
 	Name         types.String `tfsdk:"name"`
 	Description  types.String `tfsdk:"description"`
 	UUID         types.String `tfsdk:"uuid"`
@@ -66,6 +67,10 @@ func (r *InfinityWebappBrandingResource) Configure(ctx context.Context, req reso
 func (r *InfinityWebappBrandingResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Resource URI for the webapp branding package in Infinity",
+			},
 			"name": schema.StringAttribute{
 				Required: true,
 				Validators: []validator.String{
@@ -195,6 +200,7 @@ func (r *InfinityWebappBrandingResource) read(ctx context.Context, uuid string, 
 		return nil, fmt.Errorf("webapp branding with UUID '%s' not found", uuid)
 	}
 
+	data.ID = types.StringValue(srv.ResourceURI)
 	data.Name = types.StringValue(srv.Name)
 	data.Description = types.StringValue(srv.Description)
 	data.UUID = types.StringValue(srv.UUID)


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the Terraform provider's handling of webapp alias and branding resources. The main changes focus on improving schema definitions, ensuring correct data formatting between SDK and Terraform, and updating validation rules.

**Webapp Alias Resource Improvements:**

- Updated the `description` attribute in `resource_infinity_webapp_alias.go` to have a maximum length of 250 characters (down from 500), made it `Computed` with a default empty string, and updated its markdown description accordingly.
- Converted `Bundle` and `Branding` fields from SDK objects to Terraform string URIs in the `read` method, ensuring correct formatting when mapping SDK responses to Terraform state.
- Added import for `stringdefault` to support the new default value logic.
- Updated test mock logic to clarify handling of `Bundle` and `Branding` fields, noting they are not updated in the mock due to their format differences between requests and responses.

**Webapp Branding Resource Enhancements:**

- Added an `id` attribute to the `InfinityWebappBrandingResourceModel` and its schema, which is now populated with the resource URI from the SDK, improving resource identification and compatibility. [[1]](diffhunk://#diff-0e272a9bd8e748dea5237ee4f08d30fa5a2a892f1becc0e0f8f362e95a366356R37) [[2]](diffhunk://#diff-0e272a9bd8e748dea5237ee4f08d30fa5a2a892f1becc0e0f8f362e95a366356R70-R73) [[3]](diffhunk://#diff-0e272a9bd8e748dea5237ee4f08d30fa5a2a892f1becc0e0f8f362e95a366356R203)

**Dependency Update:**

- Updated `go-infinity-sdk/v38` dependency from version `v38.0.20` to `v38.0.21` in `go.mod`.

Fixes #114 