### PR TITLE
Validate gateway routing rule with outgoing protocol teams/gms and live captions

### DIFF
--- a/internal/provider/resource_infinity_gateway_routing_rule.go
+++ b/internal/provider/resource_infinity_gateway_routing_rule.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -139,7 +140,6 @@ func (r *InfinityGatewayRoutingRuleResource) Schema(ctx context.Context, req res
 			},
 			"crypto_mode": schema.StringAttribute{
 				Optional: true,
-				Computed: true,
 				Validators: []validator.String{
 					stringvalidator.OneOf("besteffort", "on", "off"),
 				},
@@ -164,6 +164,7 @@ func (r *InfinityGatewayRoutingRuleResource) Schema(ctx context.Context, req res
 				ElementType:         types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Default:             setdefault.StaticValue(types.SetValueMust(types.StringType, []attr.Value{})),
 				MarkdownDescription: "Set of disabled codecs.",
 			},
 			"enable": schema.BoolAttribute{
@@ -183,17 +184,14 @@ func (r *InfinityGatewayRoutingRuleResource) Schema(ctx context.Context, req res
 			},
 			"gms_access_token": schema.StringAttribute{
 				Optional:            true,
-				Computed:            true,
 				MarkdownDescription: "The access token to use when resolving Google Meet meeting codes.",
 			},
 			"h323_gatekeeper": schema.StringAttribute{
 				Optional:            true,
-				Computed:            true,
 				MarkdownDescription: "When calling an external system, this is the H.323 gatekeeper to use for outbound H.323 calls. Select Use DNS to try to use normal H.323 resolution procedures to route the call.",
 			},
 			"ivr_theme": schema.StringAttribute{
 				Optional:            true,
-				Computed:            true,
 				MarkdownDescription: "The theme for use with this service. If no theme is selected here, files from the theme that has been selected as the default (Platform > Global settings > Default theme) will be applied.",
 			},
 			"live_captions_enabled": schema.StringAttribute{
@@ -255,7 +253,6 @@ func (r *InfinityGatewayRoutingRuleResource) Schema(ctx context.Context, req res
 			},
 			"match_source_location": schema.StringAttribute{
 				Optional:            true,
-				Computed:            true,
 				MarkdownDescription: "Applies the rule only if the incoming call is being handled by a Conferencing Node in the selected location or the outgoing call is being initiated from the selected location. To apply the rule regardless of the location, select Any Location.",
 			},
 			"match_string": schema.StringAttribute{
@@ -273,7 +270,6 @@ func (r *InfinityGatewayRoutingRuleResource) Schema(ctx context.Context, req res
 			},
 			"max_callrate_in": schema.Int32Attribute{
 				Optional: true,
-				Computed: true,
 				Validators: []validator.Int32{
 					int32validator.Between(128, 8192),
 				},
@@ -281,7 +277,6 @@ func (r *InfinityGatewayRoutingRuleResource) Schema(ctx context.Context, req res
 			},
 			"max_callrate_out": schema.Int32Attribute{
 				Optional: true,
-				Computed: true,
 				Validators: []validator.Int32{
 					int32validator.Between(128, 8192),
 				},
@@ -289,7 +284,6 @@ func (r *InfinityGatewayRoutingRuleResource) Schema(ctx context.Context, req res
 			},
 			"max_pixels_per_second": schema.StringAttribute{
 				Optional: true,
-				Computed: true,
 				Validators: []validator.String{
 					stringvalidator.OneOf("sd", "hd", "fullhd"),
 				},
@@ -297,7 +291,6 @@ func (r *InfinityGatewayRoutingRuleResource) Schema(ctx context.Context, req res
 			},
 			"mssip_proxy": schema.StringAttribute{
 				Optional:            true,
-				Computed:            true,
 				MarkdownDescription: "When calling an external system, this is the Lync / Skype for Business server to use for outbound Lync / Skype for Business (MS-SIP) calls. Select Use DNS to try to use normal Lync / Skype for Business (MS-SIP) resolution procedures to route the call. When calling a Lync / Skype for Business meeting, this is the Lync / Skype for Business server to use for the Conference ID lookup and to place the call.",
 			},
 			"name": schema.StringAttribute{
@@ -309,8 +302,7 @@ func (r *InfinityGatewayRoutingRuleResource) Schema(ctx context.Context, req res
 			},
 			"outgoing_location": schema.StringAttribute{
 				Optional:            true,
-				Computed:            true,
-				MarkdownDescription: "When calling an external system, this forces the outgoing call to be handled by a Conferencing Node in a specific location. When calling a Lync / Skype for Business meeting, a Conferencing Node in this location will handle the outgoing call, and - for 'Lync / Skype for Business meeting direct' targets - perform the Conference ID lookup on the Lync / Skype for Business server. Select Automatic to allow Pexip Infinity to automatically select which Conferencing Node to use.",
+				MarkdownDescription: "When calling an external system, this forces the outgoing call to be handled by a Conferencing Node in a specific location. When calling a Lync / Skype for Business meeting, a Conferencing Node in this location will handle the outgoing call, and - for 'Lync / Skype for Business meeting direct' targets - perform the Conference ID lookup on the Lync / Skype for Business server. Setting to null will allow Pexip Infinity to automatically select which Conferencing Node to use.",
 			},
 			"outgoing_protocol": schema.StringAttribute{
 				Optional: true,
@@ -339,12 +331,10 @@ func (r *InfinityGatewayRoutingRuleResource) Schema(ctx context.Context, req res
 			},
 			"sip_proxy": schema.StringAttribute{
 				Optional:            true,
-				Computed:            true,
 				MarkdownDescription: "When calling an external system, this is the SIP proxy to use for outbound SIP calls. Select Use DNS to try to use normal SIP resolution procedures to route the call.",
 			},
 			"stun_server": schema.StringAttribute{
 				Optional:            true,
-				Computed:            true,
 				MarkdownDescription: "The STUN server to be used for outbound Lync / Skype for Business (MS-SIP) calls (where applicable).",
 			},
 			"tag": schema.StringAttribute{
@@ -358,12 +348,10 @@ func (r *InfinityGatewayRoutingRuleResource) Schema(ctx context.Context, req res
 			},
 			"teams_proxy": schema.StringAttribute{
 				Optional:            true,
-				Computed:            true,
 				MarkdownDescription: "The Teams Connector to use for the Teams meeting. If you do not specify anything, the Teams Connector associated with the outgoing location is used.",
 			},
 			"telehealth_profile": schema.StringAttribute{
 				Optional:            true,
-				Computed:            true,
 				MarkdownDescription: "The Telehealth Profile to use for the meeting.",
 			},
 			"treat_as_trusted": schema.BoolAttribute{
@@ -374,7 +362,6 @@ func (r *InfinityGatewayRoutingRuleResource) Schema(ctx context.Context, req res
 			},
 			"turn_server": schema.StringAttribute{
 				Optional:            true,
-				Computed:            true,
 				MarkdownDescription: "The TURN server to be used for outbound Lync / Skype for Business (MS-SIP) calls (where applicable).",
 			},
 		},
@@ -583,6 +570,7 @@ func (r *InfinityGatewayRoutingRuleResource) read(ctx context.Context, resourceI
 	}
 
 	// Convert disabled codecs from SDK to Terraform format
+	// The API always returns [] for empty disabled_codecs, never null
 	var disabledCodecs []attr.Value
 	if srv.DisabledCodecs != nil {
 		for _, v := range *srv.DisabledCodecs {

--- a/internal/provider/resource_infinity_gateway_routing_rule.go
+++ b/internal/provider/resource_infinity_gateway_routing_rule.go
@@ -788,11 +788,11 @@ func (r *InfinityGatewayRoutingRuleResource) ConfigValidators(_ context.Context)
 type gatewayRoutingRuleTeamsLiveCaptionsValidator struct{}
 
 func (v gatewayRoutingRuleTeamsLiveCaptionsValidator) Description(_ context.Context) string {
-	return "When outgoing_protocol is 'teams', live_captions_enabled must be 'no'."
+	return "When outgoing_protocol is 'teams' or 'gms', live_captions_enabled must be 'no'."
 }
 
 func (v gatewayRoutingRuleTeamsLiveCaptionsValidator) MarkdownDescription(_ context.Context) string {
-	return "When `outgoing_protocol` is `teams`, `live_captions_enabled` must be `no`."
+	return "When `outgoing_protocol` is `teams` or `gms`, `live_captions_enabled` must be `no`."
 }
 
 func (v gatewayRoutingRuleTeamsLiveCaptionsValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
@@ -812,6 +812,14 @@ func (v gatewayRoutingRuleTeamsLiveCaptionsValidator) ValidateResource(ctx conte
 			path.Root("live_captions_enabled"),
 			"Invalid live_captions_enabled for Teams protocol",
 			"When outgoing_protocol is 'teams', live_captions_enabled must be 'no'.",
+		)
+	}
+
+	if config.OutgoingProtocol.ValueString() == "gms" && config.LiveCaptionsEnabled.ValueString() != "no" {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("live_captions_enabled"),
+			"Invalid live_captions_enabled for GMS protocol",
+			"When outgoing_protocol is 'gms', live_captions_enabled must be 'no'.",
 		)
 	}
 }

--- a/internal/provider/resource_infinity_gateway_routing_rule.go
+++ b/internal/provider/resource_infinity_gateway_routing_rule.go
@@ -767,23 +767,23 @@ func (r *InfinityGatewayRoutingRuleResource) Delete(ctx context.Context, req res
 
 func (r *InfinityGatewayRoutingRuleResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
 	return []resource.ConfigValidator{
-		gatewayRoutingRuleTeamsLiveCaptionsValidator{},
+		gatewayRoutingRuleTeamsGMSLiveCaptionsValidator{},
 	}
 }
 
-// gatewayRoutingRuleTeamsLiveCaptionsValidator enforces that live_captions_enabled
-// must be "no" when outgoing_protocol is "teams".
-type gatewayRoutingRuleTeamsLiveCaptionsValidator struct{}
+// gatewayRoutingRuleTeamsGMSLiveCaptionsValidator enforces that live_captions_enabled
+// must be "no" when outgoing_protocol is "teams" or "gms".
+type gatewayRoutingRuleTeamsGMSLiveCaptionsValidator struct{}
 
-func (v gatewayRoutingRuleTeamsLiveCaptionsValidator) Description(_ context.Context) string {
+func (v gatewayRoutingRuleTeamsGMSLiveCaptionsValidator) Description(_ context.Context) string {
 	return "When outgoing_protocol is 'teams' or 'gms', live_captions_enabled must be 'no'."
 }
 
-func (v gatewayRoutingRuleTeamsLiveCaptionsValidator) MarkdownDescription(_ context.Context) string {
+func (v gatewayRoutingRuleTeamsGMSLiveCaptionsValidator) MarkdownDescription(_ context.Context) string {
 	return "When `outgoing_protocol` is `teams` or `gms`, `live_captions_enabled` must be `no`."
 }
 
-func (v gatewayRoutingRuleTeamsLiveCaptionsValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+func (v gatewayRoutingRuleTeamsGMSLiveCaptionsValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	var config InfinityGatewayRoutingRuleResourceModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)

--- a/internal/provider/resource_infinity_gateway_routing_rule.go
+++ b/internal/provider/resource_infinity_gateway_routing_rule.go
@@ -29,8 +29,8 @@ import (
 )
 
 var (
-	_ resource.ResourceWithImportState        = (*InfinityGatewayRoutingRuleResource)(nil)
-	_ resource.ResourceWithConfigValidators   = (*InfinityGatewayRoutingRuleResource)(nil)
+	_ resource.ResourceWithImportState      = (*InfinityGatewayRoutingRuleResource)(nil)
+	_ resource.ResourceWithConfigValidators = (*InfinityGatewayRoutingRuleResource)(nil)
 )
 
 type InfinityGatewayRoutingRuleResource struct {

--- a/internal/provider/resource_infinity_gateway_routing_rule.go
+++ b/internal/provider/resource_infinity_gateway_routing_rule.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -28,7 +29,8 @@ import (
 )
 
 var (
-	_ resource.ResourceWithImportState = (*InfinityGatewayRoutingRuleResource)(nil)
+	_ resource.ResourceWithImportState        = (*InfinityGatewayRoutingRuleResource)(nil)
+	_ resource.ResourceWithConfigValidators   = (*InfinityGatewayRoutingRuleResource)(nil)
 )
 
 type InfinityGatewayRoutingRuleResource struct {
@@ -772,6 +774,45 @@ func (r *InfinityGatewayRoutingRuleResource) Delete(ctx context.Context, req res
 			fmt.Sprintf("Could not delete Infinity gateway routing rule with ID %s: %s", state.ID.ValueString(), err),
 		)
 		return
+	}
+}
+
+func (r *InfinityGatewayRoutingRuleResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		gatewayRoutingRuleTeamsLiveCaptionsValidator{},
+	}
+}
+
+// gatewayRoutingRuleTeamsLiveCaptionsValidator enforces that live_captions_enabled
+// must be "no" when outgoing_protocol is "teams".
+type gatewayRoutingRuleTeamsLiveCaptionsValidator struct{}
+
+func (v gatewayRoutingRuleTeamsLiveCaptionsValidator) Description(_ context.Context) string {
+	return "When outgoing_protocol is 'teams', live_captions_enabled must be 'no'."
+}
+
+func (v gatewayRoutingRuleTeamsLiveCaptionsValidator) MarkdownDescription(_ context.Context) string {
+	return "When `outgoing_protocol` is `teams`, `live_captions_enabled` must be `no`."
+}
+
+func (v gatewayRoutingRuleTeamsLiveCaptionsValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config InfinityGatewayRoutingRuleResourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if config.OutgoingProtocol.IsUnknown() || config.LiveCaptionsEnabled.IsUnknown() {
+		return
+	}
+
+	if config.OutgoingProtocol.ValueString() == "teams" && config.LiveCaptionsEnabled.ValueString() != "no" {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("live_captions_enabled"),
+			"Invalid live_captions_enabled for Teams protocol",
+			"When outgoing_protocol is 'teams', live_captions_enabled must be 'no'.",
+		)
 	}
 }
 

--- a/internal/provider/resource_infinity_gateway_routing_rule_test.go
+++ b/internal/provider/resource_infinity_gateway_routing_rule_test.go
@@ -34,7 +34,7 @@ func TestInfinityGatewayRoutingRule(t *testing.T) {
 		ResourceURI:                     "/api/admin/configuration/v1/gateway_routing_rule/1/",
 		Name:                            "tf-test-gateway-routing-rule",
 		Description:                     "",
-		Priority:                        100,
+		Priority:                        66,
 		Enable:                          true,
 		MatchString:                     ".*@example.com",
 		ReplaceString:                   "",
@@ -59,6 +59,7 @@ func TestInfinityGatewayRoutingRule(t *testing.T) {
 		MaxPixelsPerSecond:              nil,
 		MaxCallrateIn:                   nil,
 		MaxCallrateOut:                  nil,
+		DisabledCodecs:                  &[]config.CodecValue{},
 	}
 
 	// Second resource state for match_incoming_only_if_registered test
@@ -67,7 +68,7 @@ func TestInfinityGatewayRoutingRule(t *testing.T) {
 		ResourceURI:                     "/api/admin/configuration/v1/gateway_routing_rule/2/",
 		Name:                            "tf-test-gateway-routing-rule-registered",
 		Description:                     "",
-		Priority:                        101,
+		Priority:                        67,
 		Enable:                          true,
 		MatchString:                     ".*@registered.com",
 		ReplaceString:                   "",
@@ -129,6 +130,7 @@ func TestInfinityGatewayRoutingRule(t *testing.T) {
 		mockState.ExternalParticipantAvatarLookup = req.ExternalParticipantAvatarLookup
 		mockState.LiveCaptionsEnabled = req.LiveCaptionsEnabled
 		mockState.TreatAsTrusted = req.TreatAsTrusted
+		mockState.DisabledCodecs = req.DisabledCodecs
 	}).Once()
 
 	// Step 1: Create with full config (second resource)
@@ -179,6 +181,7 @@ func TestInfinityGatewayRoutingRule(t *testing.T) {
 		mockState.ExternalParticipantAvatarLookup = req.ExternalParticipantAvatarLookup
 		mockState.LiveCaptionsEnabled = req.LiveCaptionsEnabled
 		mockState.TreatAsTrusted = req.TreatAsTrusted
+		mockState.DisabledCodecs = req.DisabledCodecs
 		if args.Get(3) != nil {
 			rule := args.Get(3).(*config.GatewayRoutingRule)
 			*rule = *mockState
@@ -221,6 +224,7 @@ func TestInfinityGatewayRoutingRule(t *testing.T) {
 		mockState.ExternalParticipantAvatarLookup = req.ExternalParticipantAvatarLookup
 		mockState.LiveCaptionsEnabled = req.LiveCaptionsEnabled
 		mockState.TreatAsTrusted = req.TreatAsTrusted
+		mockState.DisabledCodecs = req.DisabledCodecs
 	}).Once()
 
 	// Step 5: Recreate second resource (back in full config)
@@ -268,6 +272,7 @@ func TestInfinityGatewayRoutingRule(t *testing.T) {
 		mockState.ExternalParticipantAvatarLookup = req.ExternalParticipantAvatarLookup
 		mockState.LiveCaptionsEnabled = req.LiveCaptionsEnabled
 		mockState.TreatAsTrusted = req.TreatAsTrusted
+		mockState.DisabledCodecs = req.DisabledCodecs
 		if args.Get(3) != nil {
 			rule := args.Get(3).(*config.GatewayRoutingRule)
 			*rule = *mockState
@@ -431,7 +436,7 @@ func testInfinityGatewayRoutingRule(t *testing.T, client InfinityClient) {
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "name", "tf-test-gateway-routing-rule"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "description", "tf-test Gateway Routing Rule Description"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "match_string", ".*@example.com"),
-					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "priority", "100"),
+					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "priority", "66"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "enable", "false"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "match_string_full", "true"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "replace_string", "replaced@example.com"),
@@ -455,12 +460,15 @@ func testInfinityGatewayRoutingRule(t *testing.T, client InfinityClient) {
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "enable_participant_avatar_lookup", "yes"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "live_captions_enabled", "yes"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "treat_as_trusted", "true"),
+					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "disabled_codecs.#", "2"),
+					resource.TestCheckTypeSetElemAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "disabled_codecs.*", "H261"),
+					resource.TestCheckTypeSetElemAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "disabled_codecs.*", "H263"),
 					// Second resource checks
 					resource.TestCheckResourceAttrSet("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule-registered", "id"),
 					resource.TestCheckResourceAttrSet("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule-registered", "resource_id"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule-registered", "name", "tf-test-gateway-routing-rule-registered"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule-registered", "match_string", ".*@registered.com"),
-					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule-registered", "priority", "101"),
+					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule-registered", "priority", "67"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule-registered", "match_incoming_only_if_registered", "true"),
 				),
 			},
@@ -473,7 +481,7 @@ func testInfinityGatewayRoutingRule(t *testing.T, client InfinityClient) {
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "name", "tf-test-gateway-routing-rule"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "description", ""),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "match_string", ".*@example.com"),
-					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "priority", "100"),
+					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "priority", "66"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "enable", "true"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "match_string_full", "false"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "replace_string", ""),
@@ -493,6 +501,7 @@ func testInfinityGatewayRoutingRule(t *testing.T, client InfinityClient) {
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "enable_participant_avatar_lookup", "default"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "live_captions_enabled", "default"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "treat_as_trusted", "false"),
+					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "disabled_codecs.#", "0"),
 				),
 			},
 			{
@@ -509,9 +518,10 @@ func testInfinityGatewayRoutingRule(t *testing.T, client InfinityClient) {
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "name", "tf-test-gateway-routing-rule"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "description", ""),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "match_string", ".*@example.com"),
-					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "priority", "100"),
+					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "priority", "66"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "tag", ""),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "replace_string", ""),
+					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "disabled_codecs.#", "0"),
 				),
 			},
 			{
@@ -524,7 +534,7 @@ func testInfinityGatewayRoutingRule(t *testing.T, client InfinityClient) {
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "name", "tf-test-gateway-routing-rule"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "description", "tf-test Gateway Routing Rule Description"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "match_string", ".*@example.com"),
-					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "priority", "100"),
+					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "priority", "66"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "enable", "false"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "match_string_full", "true"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "replace_string", "replaced@example.com"),
@@ -548,12 +558,15 @@ func testInfinityGatewayRoutingRule(t *testing.T, client InfinityClient) {
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "enable_participant_avatar_lookup", "yes"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "live_captions_enabled", "yes"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "treat_as_trusted", "true"),
+					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "disabled_codecs.#", "2"),
+					resource.TestCheckTypeSetElemAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "disabled_codecs.*", "H261"),
+					resource.TestCheckTypeSetElemAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule", "disabled_codecs.*", "H263"),
 					// Second resource checks
 					resource.TestCheckResourceAttrSet("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule-registered", "id"),
 					resource.TestCheckResourceAttrSet("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule-registered", "resource_id"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule-registered", "name", "tf-test-gateway-routing-rule-registered"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule-registered", "match_string", ".*@registered.com"),
-					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule-registered", "priority", "101"),
+					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule-registered", "priority", "67"),
 					resource.TestCheckResourceAttr("pexip_infinity_gateway_routing_rule.tf-test-gateway-routing-rule-registered", "match_incoming_only_if_registered", "true"),
 				),
 			},

--- a/internal/provider/resource_infinity_gateway_routing_rule_test.go
+++ b/internal/provider/resource_infinity_gateway_routing_rule_test.go
@@ -345,7 +345,7 @@ resource "pexip_infinity_gateway_routing_rule" "tf-test-validator" {
 				ExpectError: regexp.MustCompile(`live_captions_enabled must be 'no'`),
 			},
 			{
-				// teams protocol with live_captions_enabled unset (null → "") must fail
+				// teams protocol with live_captions_enabled unset (defaults to "default") must fail
 				Config: providerBlock + `
 resource "pexip_infinity_gateway_routing_rule" "tf-test-validator" {
   name              = "tf-test-validator"

--- a/internal/provider/resource_infinity_gateway_routing_rule_test.go
+++ b/internal/provider/resource_infinity_gateway_routing_rule_test.go
@@ -8,6 +8,7 @@ package provider
 
 import (
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/pexip/go-infinity-sdk/v38/config"
@@ -285,6 +286,135 @@ func TestInfinityGatewayRoutingRule(t *testing.T) {
 	}).Maybe()
 
 	testInfinityGatewayRoutingRule(t, client)
+}
+
+func TestInfinityGatewayRoutingRuleConfigValidator(t *testing.T) {
+	t.Parallel()
+	_ = os.Setenv("TF_ACC", "1")
+
+	client := infinity.NewClientMock()
+
+	providerBlock := `
+terraform {
+  required_providers {
+    pexip = {
+      source  = "pexip"
+      version = "0.0.1"
+    }
+  }
+}
+
+provider "pexip" {
+  address  = "https://dev-manager.dev.pexip.network"
+  username = "admin"
+  password = "admin"
+  insecure = true
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		Steps: []resource.TestStep{
+			{
+				// teams protocol with live_captions_enabled = "yes" must fail
+				Config: providerBlock + `
+resource "pexip_infinity_gateway_routing_rule" "tf-test-validator" {
+  name                  = "tf-test-validator"
+  match_string          = ".*@example.com"
+  priority              = 100
+  outgoing_protocol     = "teams"
+  live_captions_enabled = "yes"
+}`,
+				ExpectError: regexp.MustCompile(`live_captions_enabled must be 'no'`),
+			},
+			{
+				// teams protocol with live_captions_enabled = "default" must fail
+				Config: providerBlock + `
+resource "pexip_infinity_gateway_routing_rule" "tf-test-validator" {
+  name                  = "tf-test-validator"
+  match_string          = ".*@example.com"
+  priority              = 100
+  outgoing_protocol     = "teams"
+  live_captions_enabled = "default"
+}`,
+				ExpectError: regexp.MustCompile(`live_captions_enabled must be 'no'`),
+			},
+			{
+				// teams protocol with live_captions_enabled unset (null → "") must fail
+				Config: providerBlock + `
+resource "pexip_infinity_gateway_routing_rule" "tf-test-validator" {
+  name              = "tf-test-validator"
+  match_string      = ".*@example.com"
+  priority          = 100
+  outgoing_protocol = "teams"
+}`,
+				ExpectError: regexp.MustCompile(`live_captions_enabled must be 'no'`),
+			},
+			{
+				// gms protocol with live_captions_enabled = "yes" must fail
+				Config: providerBlock + `
+resource "pexip_infinity_gateway_routing_rule" "tf-test-validator" {
+  name                  = "tf-test-validator"
+  match_string          = ".*@example.com"
+  priority              = 100
+  outgoing_protocol     = "gms"
+  live_captions_enabled = "yes"
+}`,
+				ExpectError: regexp.MustCompile(`live_captions_enabled must be 'no'`),
+			},
+			{
+				// gms protocol with live_captions_enabled = "default" must fail
+				Config: providerBlock + `
+resource "pexip_infinity_gateway_routing_rule" "tf-test-validator" {
+  name                  = "tf-test-validator"
+  match_string          = ".*@example.com"
+  priority              = 100
+  outgoing_protocol     = "gms"
+  live_captions_enabled = "default"
+}`,
+				ExpectError: regexp.MustCompile(`live_captions_enabled must be 'no'`),
+			},
+			{
+				// teams protocol with live_captions_enabled = "no" must succeed
+				Config: providerBlock + `
+resource "pexip_infinity_gateway_routing_rule" "tf-test-validator" {
+  name                  = "tf-test-validator"
+  match_string          = ".*@example.com"
+  priority              = 100
+  outgoing_protocol     = "teams"
+  live_captions_enabled = "no"
+}`,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				// gms protocol with live_captions_enabled = "no" must succeed
+				Config: providerBlock + `
+resource "pexip_infinity_gateway_routing_rule" "tf-test-validator" {
+  name                  = "tf-test-validator"
+  match_string          = ".*@example.com"
+  priority              = 100
+  outgoing_protocol     = "gms"
+  live_captions_enabled = "no"
+}`,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				// sip protocol is unrestricted — any live_captions_enabled value must succeed
+				Config: providerBlock + `
+resource "pexip_infinity_gateway_routing_rule" "tf-test-validator" {
+  name                  = "tf-test-validator"
+  match_string          = ".*@example.com"
+  priority              = 100
+  outgoing_protocol     = "sip"
+  live_captions_enabled = "yes"
+}`,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
 }
 
 func testInfinityGatewayRoutingRule(t *testing.T, client InfinityClient) {

--- a/testdata/resource_infinity_gateway_routing_rule_full/resources.tf
+++ b/testdata/resource_infinity_gateway_routing_rule_full/resources.tf
@@ -8,7 +8,7 @@ resource "pexip_infinity_gateway_routing_rule" "tf-test-gateway-routing-rule" {
   name                            = "tf-test-gateway-routing-rule"
   description                     = "tf-test Gateway Routing Rule Description"
   match_string                    = ".*@example.com"
-  priority                        = 100
+  priority                        = 66
   enable                          = false
   match_string_full               = true
   replace_string                  = "replaced@example.com"
@@ -25,6 +25,7 @@ resource "pexip_infinity_gateway_routing_rule" "tf-test-gateway-routing-rule" {
   max_pixels_per_second           = "fullhd"
   max_callrate_in                 = 2048
   max_callrate_out                = 4096
+  disabled_codecs                 = ["H261", "H263"]
 
   # Matching rules
   match_incoming_calls            = false
@@ -45,6 +46,6 @@ resource "pexip_infinity_gateway_routing_rule" "tf-test-gateway-routing-rule" {
 resource "pexip_infinity_gateway_routing_rule" "tf-test-gateway-routing-rule-registered" {
   name                              = "tf-test-gateway-routing-rule-registered"
   match_string                      = ".*@registered.com"
-  priority                          = 101
+  priority                          = 67
   match_incoming_only_if_registered = true
 }

--- a/testdata/resource_infinity_gateway_routing_rule_min/resources.tf
+++ b/testdata/resource_infinity_gateway_routing_rule_min/resources.tf
@@ -7,5 +7,5 @@
 resource "pexip_infinity_gateway_routing_rule" "tf-test-gateway-routing-rule" {
   name         = "tf-test-gateway-routing-rule"
   match_string = ".*@example.com"
-  priority     = 100
+  priority     = 66
 }


### PR DESCRIPTION
This pull request makes several improvements to the `InfinityGatewayRoutingRuleResource` in the Terraform provider, focusing on stricter validation, schema enhancements, and improved test coverage. The most significant changes include adding a custom configuration validator for protocol and live captions compatibility, refining schema attribute handling, and ensuring tests cover the new logic and state handling.

**Validation and Schema Improvements:**

* Added a custom config validator to enforce that `live_captions_enabled` must be `"no"` when `outgoing_protocol` is `"teams"` or `"gms"`, preventing invalid configurations. [[1]](diffhunk://#diff-9a8fcc0d6ab45661e8e6663a74ae81e3afa4c039c37d5e0ed07aa916db910098R34) [[2]](diffhunk://#diff-9a8fcc0d6ab45661e8e6663a74ae81e3afa4c039c37d5e0ed07aa916db910098R768-R814)
* Improved attribute schema: removed unnecessary `Computed: true` flags from many optional string and int attributes, clarified documentation, and set a default for the `disabled_codecs` set to ensure it's always an empty set if not specified. [[1]](diffhunk://#diff-9a8fcc0d6ab45661e8e6663a74ae81e3afa4c039c37d5e0ed07aa916db910098L140) [[2]](diffhunk://#diff-9a8fcc0d6ab45661e8e6663a74ae81e3afa4c039c37d5e0ed07aa916db910098R167) [[3]](diffhunk://#diff-9a8fcc0d6ab45661e8e6663a74ae81e3afa4c039c37d5e0ed07aa916db910098L184-L194) [[4]](diffhunk://#diff-9a8fcc0d6ab45661e8e6663a74ae81e3afa4c039c37d5e0ed07aa916db910098L256) [[5]](diffhunk://#diff-9a8fcc0d6ab45661e8e6663a74ae81e3afa4c039c37d5e0ed07aa916db910098L274-L298) [[6]](diffhunk://#diff-9a8fcc0d6ab45661e8e6663a74ae81e3afa4c039c37d5e0ed07aa916db910098L310-R305) [[7]](diffhunk://#diff-9a8fcc0d6ab45661e8e6663a74ae81e3afa4c039c37d5e0ed07aa916db910098L340-L345) [[8]](diffhunk://#diff-9a8fcc0d6ab45661e8e6663a74ae81e3afa4c039c37d5e0ed07aa916db910098L359-L364) [[9]](diffhunk://#diff-9a8fcc0d6ab45661e8e6663a74ae81e3afa4c039c37d5e0ed07aa916db910098L375)
* Updated documentation for the `outgoing_location` attribute to clarify that setting it to null allows automatic node selection.

**Test Enhancements:**

* Updated test resource states to reflect schema changes, including setting priorities and explicitly testing the `disabled_codecs` default behavior. [[1]](diffhunk://#diff-a4e86fd6026821d5c4e41ff16df7e077097ae5c58ba36ad91c8c4b6c68b78c69L36-R37) [[2]](diffhunk://#diff-a4e86fd6026821d5c4e41ff16df7e077097ae5c58ba36ad91c8c4b6c68b78c69R62) [[3]](diffhunk://#diff-a4e86fd6026821d5c4e41ff16df7e077097ae5c58ba36ad91c8c4b6c68b78c69L69-R71)
* Modified test mocks to correctly handle the new `disabled_codecs` logic during resource creation, update, and deletion, ensuring accurate test coverage for the new schema and validation logic. [[1]](diffhunk://#diff-a4e86fd6026821d5c4e41ff16df7e077097ae5c58ba36ad91c8c4b6c68b78c69R133) [[2]](diffhunk://#diff-a4e86fd6026821d5c4e41ff16df7e077097ae5c58ba36ad91c8c4b6c68b78c69R184) [[3]](diffhunk://#diff-a4e86fd6026821d5c4e41ff16df7e077097ae5c58ba36ad91c8c4b6c68b78c69R227) [[4]](diffhunk://#diff-a4e86fd6026821d5c4e41ff16df7e077097ae5c58ba36ad91c8c4b6c68b78c69R275)

**Code Quality and Consistency:**

* Added missing imports required for new validation and schema logic. [[1]](diffhunk://#diff-9a8fcc0d6ab45661e8e6663a74ae81e3afa4c039c37d5e0ed07aa916db910098R17-R23) [[2]](diffhunk://#diff-a4e86fd6026821d5c4e41ff16df7e077097ae5c58ba36ad91c8c4b6c68b78c69R11)
* Added a clarifying comment to document the API's behavior for empty `disabled_codecs`.

Fixes #134 

## How Has This Been Tested?

Integration test passes and lab tested.