### PR TITLE
feat: add Infinity autobackup resource and integration tests

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -234,6 +234,7 @@ func (p *PexipProvider) Resources(ctx context.Context) []func() resource.Resourc
 		func() resource.Resource { return &InfinityExternalWebappHostResource{} },
 		func() resource.Resource { return &InfinityGoogleAuthServerResource{} },
 		func() resource.Resource { return &InfinityMjxMeetingProcessingRuleResource{} },
+		func() resource.Resource { return &InfinityAutobackupResource{} },
 	}
 }
 

--- a/internal/provider/resource_infinity_autobackup.go
+++ b/internal/provider/resource_infinity_autobackup.go
@@ -1,0 +1,334 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Pexip AS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/pexip/go-infinity-sdk/v38/config"
+)
+
+var (
+	_ resource.ResourceWithImportState   = (*InfinityAutobackupResource)(nil)
+	_ resource.ResourceWithValidateConfig = (*InfinityAutobackupResource)(nil)
+)
+
+type InfinityAutobackupResource struct {
+	InfinityClient InfinityClient
+}
+
+type InfinityAutobackupResourceModel struct {
+	ID                      types.String `tfsdk:"id"`
+	AutobackupEnabled       types.Bool   `tfsdk:"autobackup_enabled"`
+	AutobackupInterval      types.Int32  `tfsdk:"autobackup_interval"`
+	AutobackupPassphrase    types.String `tfsdk:"autobackup_passphrase"`
+	AutobackupStartHour     types.Int32  `tfsdk:"autobackup_start_hour"`
+	AutobackupUploadURL     types.String `tfsdk:"autobackup_upload_url"`
+	AutobackupUploadUsername types.String `tfsdk:"autobackup_upload_username"`
+	AutobackupUploadPassword types.String `tfsdk:"autobackup_upload_password"`
+}
+
+func (r *InfinityAutobackupResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_infinity_autobackup"
+}
+
+func (r *InfinityAutobackupResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	p, ok := req.ProviderData.(*PexipProvider)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *PexipProvider, got: %T. Please report this issue to the provider developers", req.ProviderData),
+		)
+		return
+	}
+
+	r.InfinityClient = p.client
+}
+
+func (r *InfinityAutobackupResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Manages the Pexip Infinity automatic backup configuration. This is a singleton resource — only one instance exists.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Resource URI for the autobackup configuration in Infinity.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"autobackup_enabled": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+				MarkdownDescription: "Enable automatic creation of daily configuration backups.",
+			},
+			"autobackup_interval": schema.Int32Attribute{
+				Optional: true,
+				Computed: true,
+				Default:  int32default.StaticInt32(24),
+				Validators: []validator.Int32{
+					int32validator.Between(1, 24),
+				},
+				MarkdownDescription: "The number of hours between running an automatic backup. Range: 1 to 24. Default: 24.",
+			},
+			"autobackup_passphrase": schema.StringAttribute{
+				Optional:  true,
+				Computed:  true,
+				Sensitive: true,
+				Default:   stringdefault.StaticString(""),
+				Validators: []validator.String{
+					stringvalidator.LengthAtMost(100),
+				},
+				MarkdownDescription: "The passphrase used to encrypt all automatically generated backup files. Maximum length: 100 characters.",
+			},
+			"autobackup_start_hour": schema.Int32Attribute{
+				Optional: true,
+				Computed: true,
+				Default:  int32default.StaticInt32(1),
+				Validators: []validator.Int32{
+					int32validator.Between(0, 23),
+				},
+				MarkdownDescription: "The hour (in UTC time) to run the automatic backup. Range: 0 to 23. Default: 1.",
+			},
+			"autobackup_upload_url": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(""),
+				Validators: []validator.String{
+					stringvalidator.LengthAtMost(255),
+				},
+				MarkdownDescription: "The URL to which to upload automatic backups. Supported schemes: FTPS, FTP. Maximum length: 255 characters.",
+			},
+			"autobackup_upload_username": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(""),
+				Validators: []validator.String{
+					stringvalidator.LengthAtMost(100),
+				},
+				MarkdownDescription: "The username for the upload URL. Maximum length: 100 characters.",
+			},
+			"autobackup_upload_password": schema.StringAttribute{
+				Optional:  true,
+				Computed:  true,
+				Sensitive: true,
+				Default:   stringdefault.StaticString(""),
+				Validators: []validator.String{
+					stringvalidator.LengthAtMost(100),
+				},
+				MarkdownDescription: "The password for the upload URL. Maximum length: 100 characters.",
+			},
+		},
+	}
+}
+
+func (r *InfinityAutobackupResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var data InfinityAutobackupResourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.AutobackupEnabled.ValueBool() && data.AutobackupPassphrase.ValueString() == "" {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("autobackup_passphrase"),
+			"Missing Required Attribute",
+			"autobackup_passphrase must be set when autobackup_enabled is true.",
+		)
+	}
+}
+
+func (r *InfinityAutobackupResource) buildUpdateRequest(plan *InfinityAutobackupResourceModel) *config.AutobackupUpdateRequest {
+	enabled := plan.AutobackupEnabled.ValueBool()
+	interval := int(plan.AutobackupInterval.ValueInt32())
+	startHour := int(plan.AutobackupStartHour.ValueInt32())
+
+	return &config.AutobackupUpdateRequest{
+		AutobackupEnabled:        &enabled,
+		AutobackupInterval:       &interval,
+		AutobackupPassphrase:     plan.AutobackupPassphrase.ValueString(),
+		AutobackupStartHour:      &startHour,
+		AutobackupUploadURL:      plan.AutobackupUploadURL.ValueString(),
+		AutobackupUploadUsername: plan.AutobackupUploadUsername.ValueString(),
+		AutobackupUploadPassword: plan.AutobackupUploadPassword.ValueString(),
+	}
+}
+
+func (r *InfinityAutobackupResource) read(ctx context.Context, passphrase, uploadPassword string) (*InfinityAutobackupResourceModel, error) {
+	var data InfinityAutobackupResourceModel
+
+	srv, err := r.InfinityClient.Config().GetAutobackup(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if srv.ResourceURI == "" {
+		return nil, fmt.Errorf("autobackup configuration not found")
+	}
+
+	data.ID = types.StringValue(srv.ResourceURI)
+	data.AutobackupEnabled = types.BoolValue(srv.AutobackupEnabled)
+	data.AutobackupInterval = types.Int32Value(int32(srv.AutobackupInterval))
+	// Passphrase is write-only — carry the value from plan/state
+	data.AutobackupPassphrase = types.StringValue(passphrase)
+	data.AutobackupStartHour = types.Int32Value(int32(srv.AutobackupStartHour))
+	data.AutobackupUploadURL = types.StringValue(srv.AutobackupUploadURL)
+	data.AutobackupUploadUsername = types.StringValue(srv.AutobackupUploadUsername)
+	// Upload password is write-only — carry the value from plan/state
+	data.AutobackupUploadPassword = types.StringValue(uploadPassword)
+
+	return &data, nil
+}
+
+func (r *InfinityAutobackupResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	// For singleton resources, Create is actually Update since the resource always exists
+	plan := &InfinityAutobackupResourceModel{}
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	updateRequest := r.buildUpdateRequest(plan)
+
+	_, err := r.InfinityClient.Config().UpdateAutobackup(ctx, updateRequest)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Updating Infinity autobackup configuration",
+			fmt.Sprintf("Could not update Infinity autobackup configuration: %s", err),
+		)
+		return
+	}
+
+	updatedModel, err := r.read(ctx, plan.AutobackupPassphrase.ValueString(), plan.AutobackupUploadPassword.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading Updated Infinity autobackup configuration",
+			fmt.Sprintf("Could not read updated Infinity autobackup configuration: %s", err),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, updatedModel)...)
+}
+
+func (r *InfinityAutobackupResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	state := &InfinityAutobackupResourceModel{}
+
+	resp.Diagnostics.Append(req.State.Get(ctx, state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	state, err := r.read(ctx, state.AutobackupPassphrase.ValueString(), state.AutobackupUploadPassword.ValueString())
+	if err != nil {
+		if isNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error Reading Infinity autobackup configuration",
+			fmt.Sprintf("Could not read Infinity autobackup configuration: %s", err),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}
+
+func (r *InfinityAutobackupResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	plan := &InfinityAutobackupResourceModel{}
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	updateRequest := r.buildUpdateRequest(plan)
+
+	_, err := r.InfinityClient.Config().UpdateAutobackup(ctx, updateRequest)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Updating Infinity autobackup configuration",
+			fmt.Sprintf("Could not update Infinity autobackup configuration: %s", err),
+		)
+		return
+	}
+
+	updatedModel, err := r.read(ctx, plan.AutobackupPassphrase.ValueString(), plan.AutobackupUploadPassword.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading Updated Infinity autobackup configuration",
+			fmt.Sprintf("Could not read updated Infinity autobackup configuration: %s", err),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, updatedModel)...)
+}
+
+func (r *InfinityAutobackupResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	tflog.Info(ctx, "Resetting Infinity autobackup configuration to defaults")
+
+	enabled := false
+	interval := 24
+	startHour := 1
+
+	updateRequest := &config.AutobackupUpdateRequest{
+		AutobackupEnabled:        &enabled,
+		AutobackupInterval:       &interval,
+		AutobackupPassphrase:     "",
+		AutobackupStartHour:      &startHour,
+		AutobackupUploadURL:      "",
+		AutobackupUploadUsername: "",
+		AutobackupUploadPassword: "",
+	}
+
+	_, err := r.InfinityClient.Config().UpdateAutobackup(ctx, updateRequest)
+	if err != nil && !isNotFoundError(err) && !isLookupError(err) {
+		resp.Diagnostics.AddError(
+			"Error Resetting Infinity autobackup configuration",
+			fmt.Sprintf("Could not reset Infinity autobackup configuration: %s", err),
+		)
+		return
+	}
+}
+
+func (r *InfinityAutobackupResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// For singleton resources, the import ID doesn't matter since there's only one instance
+	tflog.Trace(ctx, "Importing Infinity autobackup configuration")
+
+	model, err := r.read(ctx, "", "")
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Importing Infinity Autobackup Configuration",
+			fmt.Sprintf("Could not import Infinity autobackup configuration: %s", err),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+}

--- a/internal/provider/resource_infinity_autobackup.go
+++ b/internal/provider/resource_infinity_autobackup.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	_ resource.ResourceWithImportState   = (*InfinityAutobackupResource)(nil)
+	_ resource.ResourceWithImportState    = (*InfinityAutobackupResource)(nil)
 	_ resource.ResourceWithValidateConfig = (*InfinityAutobackupResource)(nil)
 )
 
@@ -36,12 +36,12 @@ type InfinityAutobackupResource struct {
 }
 
 type InfinityAutobackupResourceModel struct {
-	ID                      types.String `tfsdk:"id"`
-	AutobackupEnabled       types.Bool   `tfsdk:"autobackup_enabled"`
-	AutobackupInterval      types.Int32  `tfsdk:"autobackup_interval"`
-	AutobackupPassphrase    types.String `tfsdk:"autobackup_passphrase"`
-	AutobackupStartHour     types.Int32  `tfsdk:"autobackup_start_hour"`
-	AutobackupUploadURL     types.String `tfsdk:"autobackup_upload_url"`
+	ID                       types.String `tfsdk:"id"`
+	AutobackupEnabled        types.Bool   `tfsdk:"autobackup_enabled"`
+	AutobackupInterval       types.Int32  `tfsdk:"autobackup_interval"`
+	AutobackupPassphrase     types.String `tfsdk:"autobackup_passphrase"`
+	AutobackupStartHour      types.Int32  `tfsdk:"autobackup_start_hour"`
+	AutobackupUploadURL      types.String `tfsdk:"autobackup_upload_url"`
 	AutobackupUploadUsername types.String `tfsdk:"autobackup_upload_username"`
 	AutobackupUploadPassword types.String `tfsdk:"autobackup_upload_password"`
 }

--- a/internal/provider/resource_infinity_autobackup_integration_test.go
+++ b/internal/provider/resource_infinity_autobackup_integration_test.go
@@ -1,0 +1,45 @@
+//go:build integration
+
+/*
+ * SPDX-FileCopyrightText: 2025 Pexip AS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package provider
+
+import (
+	"crypto/tls"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pexip/terraform-provider-pexip/internal/test"
+
+	"github.com/pexip/go-infinity-sdk/v38"
+)
+
+func TestInfinityAutobackupIntegration(t *testing.T) {
+	_ = os.Setenv("TF_ACC", "1")
+
+	client, err := infinity.New(
+		infinity.WithBaseURL(test.INFINITY_BASE_URL),
+		infinity.WithBasicAuth(test.INFINITY_USERNAME, test.INFINITY_PASSWORD),
+		infinity.WithMaxRetries(2),
+		infinity.WithTransport(&http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true, // We need this because default certificate is not trusted
+				MinVersion:         tls.VersionTLS12,
+			},
+			MaxIdleConns:        30,
+			MaxIdleConnsPerHost: 5,
+			IdleConnTimeout:     60 * time.Second,
+		}),
+	)
+	require.NoError(t, err)
+
+	testInfinityAutobackup(t, client)
+}

--- a/internal/provider/resource_infinity_autobackup_test.go
+++ b/internal/provider/resource_infinity_autobackup_test.go
@@ -61,7 +61,7 @@ func TestInfinityAutobackup(t *testing.T) {
 		*autobackup = *mockState
 	}).Maybe()
 
-	client.On("PatchJSON", mock.Anything, "configuration/v1/autobackup/1/", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+	client.On("PutJSON", mock.Anything, "configuration/v1/autobackup/1/", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		updateReq := args.Get(2).(*config.AutobackupUpdateRequest)
 		result := args.Get(3).(*config.Autobackup)
 

--- a/internal/provider/resource_infinity_autobackup_test.go
+++ b/internal/provider/resource_infinity_autobackup_test.go
@@ -1,0 +1,151 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Pexip AS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package provider
+
+import (
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/pexip/go-infinity-sdk/v38/config"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/pexip/go-infinity-sdk/v38"
+
+	"github.com/pexip/terraform-provider-pexip/internal/test"
+)
+
+func TestInfinityAutobackupValidator(t *testing.T) {
+	t.Parallel()
+	_ = os.Setenv("TF_ACC", "1")
+
+	client := infinity.NewClientMock()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "pexip_infinity_autobackup" "autobackup-test" {
+  autobackup_enabled = true
+}`,
+				ExpectError: regexp.MustCompile(`autobackup_passphrase must be set when autobackup_enabled is true`),
+			},
+		},
+	})
+}
+
+func TestInfinityAutobackup(t *testing.T) {
+	t.Parallel()
+	_ = os.Setenv("TF_ACC", "1")
+
+	client := infinity.NewClientMock()
+
+	mockState := &config.Autobackup{
+		ResourceURI:              "/api/admin/configuration/v1/autobackup/1/",
+		AutobackupEnabled:        false,
+		AutobackupInterval:       24,
+		AutobackupPassphrase:     "",
+		AutobackupStartHour:      1,
+		AutobackupUploadURL:      "",
+		AutobackupUploadUsername: "",
+		AutobackupUploadPassword: "",
+	}
+
+	client.On("GetJSON", mock.Anything, "configuration/v1/autobackup/1/", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		autobackup := args.Get(3).(*config.Autobackup)
+		*autobackup = *mockState
+	}).Maybe()
+
+	client.On("PatchJSON", mock.Anything, "configuration/v1/autobackup/1/", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		updateReq := args.Get(2).(*config.AutobackupUpdateRequest)
+		result := args.Get(3).(*config.Autobackup)
+
+		if updateReq.AutobackupEnabled != nil {
+			mockState.AutobackupEnabled = *updateReq.AutobackupEnabled
+		}
+		if updateReq.AutobackupInterval != nil {
+			mockState.AutobackupInterval = *updateReq.AutobackupInterval
+		}
+		mockState.AutobackupPassphrase = updateReq.AutobackupPassphrase
+		if updateReq.AutobackupStartHour != nil {
+			mockState.AutobackupStartHour = *updateReq.AutobackupStartHour
+		}
+		mockState.AutobackupUploadURL = updateReq.AutobackupUploadURL
+		mockState.AutobackupUploadUsername = updateReq.AutobackupUploadUsername
+		mockState.AutobackupUploadPassword = updateReq.AutobackupUploadPassword
+
+		*result = *mockState
+	}).Maybe()
+
+	testInfinityAutobackup(t, client)
+}
+
+func testInfinityAutobackup(t *testing.T, client InfinityClient) {
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create with full config
+				Config: test.LoadTestFolder(t, "resource_infinity_autobackup_full"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("pexip_infinity_autobackup.autobackup-test", "id"),
+					resource.TestCheckResourceAttr("pexip_infinity_autobackup.autobackup-test", "autobackup_enabled", "true"),
+					resource.TestCheckResourceAttr("pexip_infinity_autobackup.autobackup-test", "autobackup_interval", "12"),
+					resource.TestCheckResourceAttr("pexip_infinity_autobackup.autobackup-test", "autobackup_passphrase", "SecretPassphrase123"),
+					resource.TestCheckResourceAttr("pexip_infinity_autobackup.autobackup-test", "autobackup_start_hour", "2"),
+					resource.TestCheckResourceAttr("pexip_infinity_autobackup.autobackup-test", "autobackup_upload_url", "ftp://backup.example.com/pexip"),
+					resource.TestCheckResourceAttr("pexip_infinity_autobackup.autobackup-test", "autobackup_upload_username", "backupuser"),
+					resource.TestCheckResourceAttr("pexip_infinity_autobackup.autobackup-test", "autobackup_upload_password", "BackupPassword123"),
+				),
+			},
+			{
+				// Step 2: Update to min config
+				Config: test.LoadTestFolder(t, "resource_infinity_autobackup_min"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("pexip_infinity_autobackup.autobackup-test", "id"),
+					resource.TestCheckResourceAttr("pexip_infinity_autobackup.autobackup-test", "autobackup_enabled", "false"),
+					resource.TestCheckResourceAttr("pexip_infinity_autobackup.autobackup-test", "autobackup_interval", "24"),
+					resource.TestCheckResourceAttr("pexip_infinity_autobackup.autobackup-test", "autobackup_passphrase", ""),
+					resource.TestCheckResourceAttr("pexip_infinity_autobackup.autobackup-test", "autobackup_start_hour", "1"),
+					resource.TestCheckResourceAttr("pexip_infinity_autobackup.autobackup-test", "autobackup_upload_url", ""),
+					resource.TestCheckResourceAttr("pexip_infinity_autobackup.autobackup-test", "autobackup_upload_username", ""),
+					resource.TestCheckResourceAttr("pexip_infinity_autobackup.autobackup-test", "autobackup_upload_password", ""),
+				),
+			},
+			{
+				// Step 3: Destroy (no-op for singleton, but included for consistency)
+				Config:  test.LoadTestFolder(t, "resource_infinity_autobackup_min"),
+				Destroy: true,
+			},
+			{
+				// Step 4: Recreate with min config (actually just updates since it's a singleton)
+				Config: test.LoadTestFolder(t, "resource_infinity_autobackup_min"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("pexip_infinity_autobackup.autobackup-test", "id"),
+					resource.TestCheckResourceAttr("pexip_infinity_autobackup.autobackup-test", "autobackup_enabled", "false"),
+					resource.TestCheckResourceAttr("pexip_infinity_autobackup.autobackup-test", "autobackup_interval", "24"),
+					resource.TestCheckResourceAttr("pexip_infinity_autobackup.autobackup-test", "autobackup_start_hour", "1"),
+				),
+			},
+			{
+				// Step 5: Update to full config
+				Config: test.LoadTestFolder(t, "resource_infinity_autobackup_full"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("pexip_infinity_autobackup.autobackup-test", "id"),
+					resource.TestCheckResourceAttr("pexip_infinity_autobackup.autobackup-test", "autobackup_enabled", "true"),
+					resource.TestCheckResourceAttr("pexip_infinity_autobackup.autobackup-test", "autobackup_interval", "12"),
+					resource.TestCheckResourceAttr("pexip_infinity_autobackup.autobackup-test", "autobackup_passphrase", "SecretPassphrase123"),
+					resource.TestCheckResourceAttr("pexip_infinity_autobackup.autobackup-test", "autobackup_start_hour", "2"),
+					resource.TestCheckResourceAttr("pexip_infinity_autobackup.autobackup-test", "autobackup_upload_url", "ftp://backup.example.com/pexip"),
+					resource.TestCheckResourceAttr("pexip_infinity_autobackup.autobackup-test", "autobackup_upload_username", "backupuser"),
+					resource.TestCheckResourceAttr("pexip_infinity_autobackup.autobackup-test", "autobackup_upload_password", "BackupPassword123"),
+				),
+			},
+		},
+	})
+}

--- a/testdata/resource_infinity_autobackup_full/providers.tf
+++ b/testdata/resource_infinity_autobackup_full/providers.tf
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Pexip AS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+terraform {
+  required_providers {
+    pexip = {
+      source  = "pexip"
+      version = "0.0.1"
+    }
+  }
+}
+
+provider "pexip" {
+  address  = "https://dev-manager.dev.pexip.network"
+  username = "admin"
+  password = "admin"
+  insecure = true
+}

--- a/testdata/resource_infinity_autobackup_full/resources.tf
+++ b/testdata/resource_infinity_autobackup_full/resources.tf
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Pexip AS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+resource "pexip_infinity_autobackup" "autobackup-test" {
+  autobackup_enabled         = true
+  autobackup_interval        = 12
+  autobackup_passphrase      = "SecretPassphrase123"
+  autobackup_start_hour      = 2
+  autobackup_upload_url      = "ftp://backup.example.com/pexip"
+  autobackup_upload_username = "backupuser"
+  autobackup_upload_password = "BackupPassword123"
+}

--- a/testdata/resource_infinity_autobackup_min/providers.tf
+++ b/testdata/resource_infinity_autobackup_min/providers.tf
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Pexip AS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+terraform {
+  required_providers {
+    pexip = {
+      source  = "pexip"
+      version = "0.0.1"
+    }
+  }
+}
+
+provider "pexip" {
+  address  = "https://dev-manager.dev.pexip.network"
+  username = "admin"
+  password = "admin"
+  insecure = true
+}

--- a/testdata/resource_infinity_autobackup_min/resources.tf
+++ b/testdata/resource_infinity_autobackup_min/resources.tf
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Pexip AS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+resource "pexip_infinity_autobackup" "autobackup-test" {
+}


### PR DESCRIPTION
This pull request introduces a new Terraform resource to manage the Pexip Infinity automatic backup ("autobackup") configuration, including full implementation, validation, and testing. The new resource is a singleton, allowing management of only one autobackup configuration at a time. The changes also include comprehensive unit and integration tests, as well as example Terraform configurations for both minimal and full setups.

**New resource implementation:**

* Added the `InfinityAutobackupResource` to the provider, enabling CRUD operations for the Pexip Infinity autobackup configuration, including schema definition, validation (e.g., requiring a passphrase when enabled), and logic for handling sensitive fields. (`internal/provider/resource_infinity_autobackup.go`)
* Registered the new resource in the provider's resource list, making it available to users. (`internal/provider/provider.go`)

**Testing:**

* Added comprehensive unit tests for the new resource, covering validation logic, full and minimal configuration scenarios, update flows, and singleton semantics. (`internal/provider/resource_infinity_autobackup_test.go`)
* Added an integration test to verify the new resource against a real Infinity instance. (`internal/provider/resource_infinity_autobackup_integration_test.go`)

**Example configurations:**

* Added example Terraform configurations for both full and minimal autobackup setups, including provider and resource definitions, to the `testdata` directory. (`testdata/resource_infinity_autobackup_full/providers.tf`, `testdata/resource_infinity_autobackup_full/resources.tf`, `testdata/resource_infinity_autobackup_min/providers.tf`, `testdata/resource_infinity_autobackup_min/resources.tf`) [[1]](diffhunk://#diff-234e63fbce5c7a12e5f5e11a9a364f8a89216205eae6bba6402c18933b9f7e57R1-R21) [[2]](diffhunk://#diff-08c53258c6522b1c70f70e84c2f1fedfe4107afabce6798d49702f9ec32a1464R1-R15) [[3]](diffhunk://#diff-d25e16a8449d45a266a37ab00a9ab066f7134fb7968e2379df4e403335661e97R1-R8)

Closes #146 