### PR TITLE
chore: bump go-infinity-sdk to v38.0.32

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.29.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
-	github.com/pexip/go-infinity-sdk/v38 v38.0.31
+	github.com/pexip/go-infinity-sdk/v38 v38.0.32
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.45.0
 )

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
-github.com/pexip/go-infinity-sdk/v38 v38.0.31 h1:o51iyJnGR9N+3v3hF8wuWH2DFeuIooRe1anxEEShPmg=
-github.com/pexip/go-infinity-sdk/v38 v38.0.31/go.mod h1:gtMzH/Mhk51u1oNkmM38cgQUV9NJc5pguq3gj3hABxk=
+github.com/pexip/go-infinity-sdk/v38 v38.0.32 h1:+/wMOXZXZzYG5FbY0Yr2aTOAJF/M/I+lXywiHRiB7uM=
+github.com/pexip/go-infinity-sdk/v38 v38.0.32/go.mod h1:gtMzH/Mhk51u1oNkmM38cgQUV9NJc5pguq3gj3hABxk=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=
 github.com/pjbgf/sha1cd v0.3.2/go.mod h1:zQWigSxVmsHEZow5qaLtPYxpcKMMQpa09ixqBxuCS6A=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/provider/resource_infinity_autobackup_test.go
+++ b/internal/provider/resource_infinity_autobackup_test.go
@@ -61,7 +61,7 @@ func TestInfinityAutobackup(t *testing.T) {
 		*autobackup = *mockState
 	}).Maybe()
 
-	client.On("PutJSON", mock.Anything, "configuration/v1/autobackup/1/", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+	client.On("PatchJSON", mock.Anything, "configuration/v1/autobackup/1/", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		updateReq := args.Get(2).(*config.AutobackupUpdateRequest)
 		result := args.Get(3).(*config.Autobackup)
 


### PR DESCRIPTION
Bump Infinity SDK version to 38.0.2 to fix an issue with the autobackup resource.