### PR TITLE
chore: Update provider tests to use ProtoV6ProviderFactories

### DIFF
--- a/internal/provider/action_infinity_delete_default_mgr_tls_certificate_test.go
+++ b/internal/provider/action_infinity_delete_default_mgr_tls_certificate_test.go
@@ -33,7 +33,7 @@ func TestInfinityDeleteDefaultMgrTLSCertificateAction(t *testing.T) {
 
 func testInfinityDeleteDefaultMgrTLSCertificateAction(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: test.LoadTestFolder(t, "action_infinity_delete_default_mgr_tls_certificate_basic"),

--- a/internal/provider/data_infinity_manager_config_test.go
+++ b/internal/provider/data_infinity_manager_config_test.go
@@ -33,7 +33,7 @@ func TestInfinityManagerConfig(t *testing.T) {
 
 func testInfinityManagerConfig(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: test.LoadTestFolder(t, "data_infinity_manager_config_basic"),

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -11,13 +11,13 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func getTestProtoV5ProviderFactories(client InfinityClient) map[string]func() (tfprotov5.ProviderServer, error) {
-	return map[string]func() (tfprotov5.ProviderServer, error){
-		"pexip": providerserver.NewProtocol5WithError(newTestProvider(client)),
+func getTestProtoV6ProviderFactories(client InfinityClient) map[string]func() (tfprotov6.ProviderServer, error) {
+	return map[string]func() (tfprotov6.ProviderServer, error){
+		"pexip": providerserver.NewProtocol6WithError(newTestProvider(client)),
 	}
 }
 

--- a/internal/provider/resource_infinity_adfs_auth_server_test.go
+++ b/internal/provider/resource_infinity_adfs_auth_server_test.go
@@ -91,7 +91,7 @@ func TestInfinityADFSAuthServer(t *testing.T) {
 
 func testInfinityADFSAuthServer(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Test 1: Create with full configuration
 			{

--- a/internal/provider/resource_infinity_authentication_test.go
+++ b/internal/provider/resource_infinity_authentication_test.go
@@ -223,7 +223,7 @@ func TestInfinityAuthentication(t *testing.T) {
 
 func testInfinityAuthentication(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"tls": {
 				Source: "hashicorp/tls",
@@ -320,7 +320,7 @@ func TestInfinityAuthenticationValidation(t *testing.T) {
 	client := infinity.NewClientMock()
 
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: `

--- a/internal/provider/resource_infinity_autobackup_test.go
+++ b/internal/provider/resource_infinity_autobackup_test.go
@@ -27,7 +27,7 @@ func TestInfinityAutobackupValidator(t *testing.T) {
 	client := infinity.NewClientMock()
 
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "pexip_infinity_autobackup" "autobackup-test" {
@@ -87,7 +87,7 @@ func TestInfinityAutobackup(t *testing.T) {
 
 func testInfinityAutobackup(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				// Step 1: Create with full config

--- a/internal/provider/resource_infinity_automatic_participant_test.go
+++ b/internal/provider/resource_infinity_automatic_participant_test.go
@@ -168,7 +168,7 @@ func TestInfinityAutomaticParticipant(t *testing.T) {
 
 func testInfinityAutomaticParticipant(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Test 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_azure_tenant_test.go
+++ b/internal/provider/resource_infinity_azure_tenant_test.go
@@ -73,7 +73,7 @@ func TestInfinityAzureTenant(t *testing.T) {
 
 func testInfinityAzureTenant(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: test.LoadTestFolder(t, "resource_infinity_azure_tenant_full"),

--- a/internal/provider/resource_infinity_break_in_allow_list_address_test.go
+++ b/internal/provider/resource_infinity_break_in_allow_list_address_test.go
@@ -105,7 +105,7 @@ func TestInfinityBreakInAllowListAddress(t *testing.T) {
 
 func testInfinityBreakInAllowListAddress(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Test 1: Create with full configuration
 			{

--- a/internal/provider/resource_infinity_ca_certificate_test.go
+++ b/internal/provider/resource_infinity_ca_certificate_test.go
@@ -99,7 +99,7 @@ g2OX6o8rGmwv2UgI1X+x9kLrdj0OFenKrwaBiEI=
 
 func testInfinityCACertificate(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: test.LoadTestFolder(t, "resource_infinity_ca_certificate_basic"),

--- a/internal/provider/resource_infinity_certificate_signing_request_test.go
+++ b/internal/provider/resource_infinity_certificate_signing_request_test.go
@@ -99,7 +99,7 @@ func TestInfinityCertificateSigningRequest(t *testing.T) {
 
 func testInfinityCertificateSigningRequest(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: test.LoadTestFolder(t, "resource_infinity_certificate_signing_request_basic"),

--- a/internal/provider/resource_infinity_conference_alias_test.go
+++ b/internal/provider/resource_infinity_conference_alias_test.go
@@ -124,7 +124,7 @@ func TestInfinityConferenceAlias(t *testing.T) {
 
 func testInfinityConferenceAlias(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_conference_integration_test.go
+++ b/internal/provider/resource_infinity_conference_integration_test.go
@@ -47,7 +47,7 @@ func TestInfinityConferenceIntegration(t *testing.T) {
 
 func testInfinityConferenceIntegration(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full configuration
 			{

--- a/internal/provider/resource_infinity_conference_test.go
+++ b/internal/provider/resource_infinity_conference_test.go
@@ -202,7 +202,7 @@ func TestInfinityConference(t *testing.T) {
 
 func testInfinityConference(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Test 1: Create with full configuration
 			{

--- a/internal/provider/resource_infinity_device_test.go
+++ b/internal/provider/resource_infinity_device_test.go
@@ -141,7 +141,7 @@ func TestInfinityDevice(t *testing.T) {
 func testInfinityDevice(t *testing.T, client InfinityClient) {
 	// Test 1 & 2: Create with full config, update to min config, then delete
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Test 1: Create with full config
 			{
@@ -178,7 +178,7 @@ func testInfinityDevice(t *testing.T, client InfinityClient) {
 
 	// Test 3 & 4: Create with min config, update to full config
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Test 3: Create with min config
 			{

--- a/internal/provider/resource_infinity_diagnostic_graph_test.go
+++ b/internal/provider/resource_infinity_diagnostic_graph_test.go
@@ -75,7 +75,7 @@ func TestInfinityDiagnosticGraph(t *testing.T) {
 
 func testInfinityDiagnosticGraph(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: test.LoadTestFolder(t, "resource_infinity_diagnostic_graph_basic"),

--- a/internal/provider/resource_infinity_dns_server_test.go
+++ b/internal/provider/resource_infinity_dns_server_test.go
@@ -94,7 +94,7 @@ func TestInfinityDNSServer(t *testing.T) {
 
 func testInfinityDNSServer(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				// Step 1: Create with full config

--- a/internal/provider/resource_infinity_end_user_test.go
+++ b/internal/provider/resource_infinity_end_user_test.go
@@ -147,7 +147,7 @@ func TestInfinityEndUser(t *testing.T) {
 
 func testInfinityEndUser(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				// Step 1: Create with full config

--- a/internal/provider/resource_infinity_event_sink_test.go
+++ b/internal/provider/resource_infinity_event_sink_test.go
@@ -132,7 +132,7 @@ func TestInfinityEventSink(t *testing.T) {
 
 func testInfinityEventSink(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				// Step 1: Create with full config

--- a/internal/provider/resource_infinity_external_webapp_host_test.go
+++ b/internal/provider/resource_infinity_external_webapp_host_test.go
@@ -67,7 +67,7 @@ func TestInfinityExternalWebappHost(t *testing.T) {
 
 func testInfinityExternalWebappHost(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				// Step 1: Create

--- a/internal/provider/resource_infinity_gateway_routing_rule_test.go
+++ b/internal/provider/resource_infinity_gateway_routing_rule_test.go
@@ -318,7 +318,7 @@ provider "pexip" {
 `
 
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				// teams protocol with live_captions_enabled = "yes" must fail
@@ -424,7 +424,7 @@ resource "pexip_infinity_gateway_routing_rule" "tf-test-validator" {
 
 func testInfinityGatewayRoutingRule(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				// Step 1: Create with full config

--- a/internal/provider/resource_infinity_global_configuration_integration_test.go
+++ b/internal/provider/resource_infinity_global_configuration_integration_test.go
@@ -50,7 +50,7 @@ func testInfinityGlobalConfigurationIntegration(t *testing.T, client InfinityCli
 	// all fields to API defaults, clearing any references to related resources. Once those
 	// references are cleared, the related resources can be deleted normally in the destroy step.
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"tls": {
 				Source: "hashicorp/tls",

--- a/internal/provider/resource_infinity_global_configuration_test.go
+++ b/internal/provider/resource_infinity_global_configuration_test.go
@@ -415,7 +415,7 @@ func TestInfinityGlobalConfiguration(t *testing.T) {
 
 func testInfinityGlobalConfiguration(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Apply full configuration with all fields set to non-default values.
 			{
@@ -515,7 +515,7 @@ func TestInfinityGlobalConfigurationValidation(t *testing.T) {
 	client := infinity.NewClientMock()
 
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				// bursting_enabled=true with no cloud_provider (defaults to AWS) but no AWS keys — expect errors

--- a/internal/provider/resource_infinity_gms_access_token_test.go
+++ b/internal/provider/resource_infinity_gms_access_token_test.go
@@ -75,7 +75,7 @@ func TestInfinityGMSAccessToken(t *testing.T) {
 
 func testInfinityGMSAccessToken(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: test.LoadTestFolder(t, "resource_infinity_gms_access_token_basic"),

--- a/internal/provider/resource_infinity_gms_gateway_token_test.go
+++ b/internal/provider/resource_infinity_gms_gateway_token_test.go
@@ -90,7 +90,7 @@ func testInfinityGMSGatewayToken(t *testing.T, client InfinityClient) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with min config
 			{

--- a/internal/provider/resource_infinity_google_auth_server_test.go
+++ b/internal/provider/resource_infinity_google_auth_server_test.go
@@ -87,7 +87,7 @@ func TestInfinityGoogleAuthServer(t *testing.T) {
 
 func testInfinityGoogleAuthServer(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: test.LoadTestFolder(t, "resource_infinity_google_auth_server_basic"),

--- a/internal/provider/resource_infinity_h323_gatekeeper_test.go
+++ b/internal/provider/resource_infinity_h323_gatekeeper_test.go
@@ -102,7 +102,7 @@ func TestInfinityH323Gatekeeper(t *testing.T) {
 
 func testInfinityH323Gatekeeper(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				// Step 1: Create with full config

--- a/internal/provider/resource_infinity_http_proxy_test.go
+++ b/internal/provider/resource_infinity_http_proxy_test.go
@@ -116,7 +116,7 @@ func TestInfinityHTTPProxy(t *testing.T) {
 
 func testInfinityHTTPProxy(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				// Step 1: Create with full config

--- a/internal/provider/resource_infinity_identity_provider_attribute_test.go
+++ b/internal/provider/resource_infinity_identity_provider_attribute_test.go
@@ -71,7 +71,7 @@ func TestInfinityIdentityProviderAttribute(t *testing.T) {
 
 func testInfinityIdentityProviderAttribute(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_identity_provider_group_test.go
+++ b/internal/provider/resource_infinity_identity_provider_group_test.go
@@ -72,7 +72,7 @@ func TestInfinityIdentityProviderGroup(t *testing.T) {
 
 func testInfinityIdentityProviderGroup(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_identity_provider_test.go
+++ b/internal/provider/resource_infinity_identity_provider_test.go
@@ -261,7 +261,7 @@ func TestInfinityIdentityProvider(t *testing.T) {
 
 func testInfinityIdentityProvider(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"random": {
 				Source: "hashicorp/random",

--- a/internal/provider/resource_infinity_ivr_theme_test.go
+++ b/internal/provider/resource_infinity_ivr_theme_test.go
@@ -67,7 +67,7 @@ func TestInfinityIvrTheme(t *testing.T) {
 
 func testInfinityIvrTheme(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_ldap_role_test.go
+++ b/internal/provider/resource_infinity_ldap_role_test.go
@@ -125,7 +125,7 @@ func TestInfinityLdapRole(t *testing.T) {
 
 func testInfinityLdapRole(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Test 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_ldap_sync_field_test.go
+++ b/internal/provider/resource_infinity_ldap_sync_field_test.go
@@ -81,7 +81,7 @@ func TestInfinityLdapSyncField(t *testing.T) {
 
 func testInfinityLdapSyncField(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Test 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_ldap_sync_source_test.go
+++ b/internal/provider/resource_infinity_ldap_sync_source_test.go
@@ -99,7 +99,7 @@ func TestInfinityLdapSyncSource(t *testing.T) {
 
 func testInfinityLdapSyncSource(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: test.LoadTestFolder(t, "resource_infinity_ldap_sync_source_basic"),

--- a/internal/provider/resource_infinity_licence_request_test.go
+++ b/internal/provider/resource_infinity_licence_request_test.go
@@ -58,7 +58,7 @@ func TestInfinityLicenceRequest(t *testing.T) {
 
 func testInfinityLicenceRequest(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		// Skip the final destroy since this resource cannot be deleted.
 		// The test already verifies that a destroy operation fails as expected.
 		CheckDestroy: func(s *terraform.State) error {

--- a/internal/provider/resource_infinity_licence_test.go
+++ b/internal/provider/resource_infinity_licence_test.go
@@ -75,7 +75,7 @@ func TestInfinityLicence(t *testing.T) {
 
 func testInfinityLicence(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: test.LoadTestFolder(t, "resource_infinity_licence"),

--- a/internal/provider/resource_infinity_log_level_test.go
+++ b/internal/provider/resource_infinity_log_level_test.go
@@ -80,7 +80,7 @@ func TestInfinityLogLevel(t *testing.T) {
 
 func testInfinityLogLevel(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_management_vm_integration_test.go
+++ b/internal/provider/resource_infinity_management_vm_integration_test.go
@@ -50,7 +50,7 @@ func testInfinityManagementVMIntegration(t *testing.T, client InfinityClient) {
 	// all fields to API defaults, clearing any references to related resources. Once those
 	// references are cleared, the related resources can be deleted normally in the destroy step.
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"tls": {
 				Source: "hashicorp/tls",

--- a/internal/provider/resource_infinity_management_vm_test.go
+++ b/internal/provider/resource_infinity_management_vm_test.go
@@ -159,7 +159,7 @@ func TestInfinityManagementVM(t *testing.T) {
 
 func testInfinityManagementVM(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Set all configurable values
 			{
@@ -233,7 +233,7 @@ func TestInfinityManagementVMValidation(t *testing.T) {
 	client := infinity.NewClientMock()
 
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: `

--- a/internal/provider/resource_infinity_media_library_entry_integration_test.go
+++ b/internal/provider/resource_infinity_media_library_entry_integration_test.go
@@ -47,7 +47,7 @@ func TestInfinityMediaLibraryEntryIntegration(t *testing.T) {
 
 func testInfinityMediaLibraryEntryIntegration(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_media_library_entry_test.go
+++ b/internal/provider/resource_infinity_media_library_entry_test.go
@@ -123,7 +123,7 @@ func TestInfinityMediaLibraryEntry(t *testing.T) {
 
 func testInfinityMediaLibraryEntry(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_media_library_playlist_entry_integration_test.go
+++ b/internal/provider/resource_infinity_media_library_playlist_entry_integration_test.go
@@ -47,7 +47,7 @@ func TestInfinityMediaLibraryPlaylistEntryIntegration(t *testing.T) {
 
 func testAccInfinityMediaLibraryPlaylistEntry(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				// Step 1: Create with full config

--- a/internal/provider/resource_infinity_media_library_playlist_entry_test.go
+++ b/internal/provider/resource_infinity_media_library_playlist_entry_test.go
@@ -85,7 +85,7 @@ func TestInfinityMediaLibraryPlaylistEntry(t *testing.T) {
 
 func testInfinityMediaLibraryPlaylistEntry(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				// Step 1: Create with full config

--- a/internal/provider/resource_infinity_media_library_playlist_integration_test.go
+++ b/internal/provider/resource_infinity_media_library_playlist_integration_test.go
@@ -47,7 +47,7 @@ func TestInfinityMediaLibraryPlaylistIntegration(t *testing.T) {
 
 func testInfinityMediaLibraryPlaylistIntegration(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_media_library_playlist_test.go
+++ b/internal/provider/resource_infinity_media_library_playlist_test.go
@@ -99,7 +99,7 @@ func TestInfinityMediaLibraryPlaylist(t *testing.T) {
 
 func testInfinityMediaLibraryPlaylist(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_media_processing_server_integration_test.go
+++ b/internal/provider/resource_infinity_media_processing_server_integration_test.go
@@ -45,7 +45,7 @@ func TestInfinityMediaProcessingServerIntegration(t *testing.T) {
 
 func testInfinityMediaProcessingServerIntegration(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: test.LoadTestFolder(t, "resource_infinity_media_processing_server_full"),

--- a/internal/provider/resource_infinity_media_processing_server_test.go
+++ b/internal/provider/resource_infinity_media_processing_server_test.go
@@ -73,7 +73,7 @@ func TestInfinityMediaProcessingServer(t *testing.T) {
 
 func testInfinityMediaProcessingServer(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Test 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_mjx_endpoint_group_integration_test.go
+++ b/internal/provider/resource_infinity_mjx_endpoint_group_integration_test.go
@@ -47,7 +47,7 @@ func TestInfinityMjxEndpointGroupIntegration(t *testing.T) {
 
 func testInfinityMjxEndpointGroupIntegration(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_mjx_endpoint_group_test.go
+++ b/internal/provider/resource_infinity_mjx_endpoint_group_test.go
@@ -66,7 +66,7 @@ func TestInfinityMjxEndpointGroup(t *testing.T) {
 
 func testInfinityMjxEndpointGroup(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_mjx_endpoint_test.go
+++ b/internal/provider/resource_infinity_mjx_endpoint_test.go
@@ -83,7 +83,7 @@ func TestInfinityMjxEndpoint(t *testing.T) {
 
 func testInfinityMjxEndpoint(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_mjx_exchange_autodiscover_url_integration_test.go
+++ b/internal/provider/resource_infinity_mjx_exchange_autodiscover_url_integration_test.go
@@ -47,7 +47,7 @@ func TestInfinityMjxExchangeAutodiscoverURLIntegration(t *testing.T) {
 
 func testInfinityMjxExchangeAutodiscoverURLIntegration(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_mjx_exchange_autodiscover_url_test.go
+++ b/internal/provider/resource_infinity_mjx_exchange_autodiscover_url_test.go
@@ -64,7 +64,7 @@ func TestInfinityMjxExchangeAutodiscoverURL(t *testing.T) {
 
 func testInfinityMjxExchangeAutodiscoverURL(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_mjx_exchange_deployment_test.go
+++ b/internal/provider/resource_infinity_mjx_exchange_deployment_test.go
@@ -107,7 +107,7 @@ func TestInfinityMjxExchangeDeployment(t *testing.T) {
 
 func testInfinityMjxExchangeDeployment(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_mjx_google_deployment_integration_test.go
+++ b/internal/provider/resource_infinity_mjx_google_deployment_integration_test.go
@@ -47,7 +47,7 @@ func TestInfinityMjxGoogleDeploymentIntegration(t *testing.T) {
 
 func testInfinityMjxGoogleDeploymentIntegration(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"tls": {
 				Source: "hashicorp/tls",

--- a/internal/provider/resource_infinity_mjx_google_deployment_test.go
+++ b/internal/provider/resource_infinity_mjx_google_deployment_test.go
@@ -82,7 +82,7 @@ func TestInfinityMjxGoogleDeployment(t *testing.T) {
 
 func testInfinityMjxGoogleDeployment(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_mjx_graph_deployment_test.go
+++ b/internal/provider/resource_infinity_mjx_graph_deployment_test.go
@@ -77,7 +77,7 @@ func TestInfinityMjxGraphDeployment(t *testing.T) {
 
 func testInfinityMjxGraphDeployment(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_mjx_integration_integration_test.go
+++ b/internal/provider/resource_infinity_mjx_integration_integration_test.go
@@ -47,7 +47,7 @@ func TestInfinityMjxIntegrationIntegration(t *testing.T) {
 
 func testInfinityMjxIntegrationIntegration(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_mjx_integration_test.go
+++ b/internal/provider/resource_infinity_mjx_integration_test.go
@@ -107,7 +107,7 @@ func TestInfinityMjxIntegration(t *testing.T) {
 
 func testInfinityMjxIntegration(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_mjx_meeting_processing_rule_integration_test.go
+++ b/internal/provider/resource_infinity_mjx_meeting_processing_rule_integration_test.go
@@ -47,7 +47,7 @@ func TestInfinityMjxMeetingProcessingRuleIntegration(t *testing.T) {
 
 func testInfinityMjxMeetingProcessingRuleIntegration(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_mjx_meeting_processing_rule_test.go
+++ b/internal/provider/resource_infinity_mjx_meeting_processing_rule_test.go
@@ -84,7 +84,7 @@ func TestInfinityMjxMeetingProcessingRule(t *testing.T) {
 
 func testInfinityMjxMeetingProcessingRule(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_ms_exchange_connector_test.go
+++ b/internal/provider/resource_infinity_ms_exchange_connector_test.go
@@ -281,7 +281,7 @@ func TestInfinityMsExchangeConnector(t *testing.T) {
 
 func testInfinityMsExchangeConnector(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: test.LoadTestFolder(t, "resource_infinity_ms_exchange_connector_basic"),

--- a/internal/provider/resource_infinity_mssip_proxy_test.go
+++ b/internal/provider/resource_infinity_mssip_proxy_test.go
@@ -107,7 +107,7 @@ func TestInfinityMSSIPProxy(t *testing.T) {
 
 func testInfinityMSSIPProxy(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				// Step 1: Create with full config

--- a/internal/provider/resource_infinity_ntp_server_test.go
+++ b/internal/provider/resource_infinity_ntp_server_test.go
@@ -90,7 +90,7 @@ func TestInfinityNTPServer(t *testing.T) {
 
 func testInfinityNTPServer(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				// Step 1: Create with full config

--- a/internal/provider/resource_infinity_oauth2_client_integration_test.go
+++ b/internal/provider/resource_infinity_oauth2_client_integration_test.go
@@ -45,7 +45,7 @@ func TestInfinityOAuth2ClientIntegration(t *testing.T) {
 
 func testInfinityOAuth2ClientIntegration(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: test.LoadTestFolder(t, "resource_infinity_oauth2_client_full"),

--- a/internal/provider/resource_infinity_oauth2_client_test.go
+++ b/internal/provider/resource_infinity_oauth2_client_test.go
@@ -81,7 +81,7 @@ func TestInfinityOAuth2Client(t *testing.T) {
 
 func testInfinityOAuth2Client(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: test.LoadTestFolder(t, "resource_infinity_oauth2_client_full"),

--- a/internal/provider/resource_infinity_pexip_streaming_credential_test.go
+++ b/internal/provider/resource_infinity_pexip_streaming_credential_test.go
@@ -84,7 +84,7 @@ mwIDAQAB
 
 func testInfinityPexipStreamingCredential(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: test.LoadTestFolder(t, "resource_infinity_pexip_streaming_credential_basic"),

--- a/internal/provider/resource_infinity_policy_server_test.go
+++ b/internal/provider/resource_infinity_policy_server_test.go
@@ -210,7 +210,7 @@ func TestInfinityPolicyServer(t *testing.T) {
 
 func testInfinityPolicyServer(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				// Step 1: Create with full config

--- a/internal/provider/resource_infinity_recurring_conference_test.go
+++ b/internal/provider/resource_infinity_recurring_conference_test.go
@@ -142,7 +142,7 @@ func TestInfinityRecurringConference(t *testing.T) {
 
 func testInfinityRecurringConference(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: test.LoadTestFolder(t, "resource_infinity_recurring_conference_basic"),

--- a/internal/provider/resource_infinity_registration_test.go
+++ b/internal/provider/resource_infinity_registration_test.go
@@ -153,7 +153,7 @@ func TestInfinityRegistration(t *testing.T) {
 
 func testInfinityRegistration(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Apply full configuration with all fields set to non-default values.
 			{
@@ -209,7 +209,7 @@ func TestInfinityRegistrationValidation(t *testing.T) {
 	client := infinity.NewClientMock()
 
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: `

--- a/internal/provider/resource_infinity_role_mapping_test.go
+++ b/internal/provider/resource_infinity_role_mapping_test.go
@@ -127,7 +127,7 @@ func TestInfinityRoleMapping(t *testing.T) {
 
 func testInfinityRoleMapping(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Test 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_role_test.go
+++ b/internal/provider/resource_infinity_role_test.go
@@ -90,7 +90,7 @@ func TestInfinityRole(t *testing.T) {
 
 func testInfinityRole(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_scheduled_alias_test.go
+++ b/internal/provider/resource_infinity_scheduled_alias_test.go
@@ -208,7 +208,7 @@ func TestInfinityScheduledAlias(t *testing.T) {
 
 func testInfinityScheduledAlias(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: test.LoadTestFolder(t, "resource_infinity_scheduled_alias_basic"),

--- a/internal/provider/resource_infinity_scheduled_conference_test.go
+++ b/internal/provider/resource_infinity_scheduled_conference_test.go
@@ -155,7 +155,7 @@ func TestInfinityScheduledConference(t *testing.T) {
 
 func testInfinityScheduledConference(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: test.LoadTestFolder(t, "resource_infinity_scheduled_conference_basic"),

--- a/internal/provider/resource_infinity_scheduled_scaling_test.go
+++ b/internal/provider/resource_infinity_scheduled_scaling_test.go
@@ -229,7 +229,7 @@ func TestInfinityScheduledScaling(t *testing.T) {
 
 func testInfinityScheduledScaling(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				// Step 1: Create with full config

--- a/internal/provider/resource_infinity_sip_credential_test.go
+++ b/internal/provider/resource_infinity_sip_credential_test.go
@@ -78,7 +78,7 @@ func TestInfinitySIPCredential(t *testing.T) {
 
 func testInfinitySIPCredential(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_sip_proxy_test.go
+++ b/internal/provider/resource_infinity_sip_proxy_test.go
@@ -75,7 +75,7 @@ func TestInfinitySIPProxy(t *testing.T) {
 
 func testInfinitySIPProxy(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				// Step 1: Create with full config

--- a/internal/provider/resource_infinity_smtp_server_test.go
+++ b/internal/provider/resource_infinity_smtp_server_test.go
@@ -97,7 +97,7 @@ func TestInfinitySMTPServer(t *testing.T) {
 
 func testInfinitySMTPServer(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				// Step 1: Create with full config

--- a/internal/provider/resource_infinity_snmp_network_management_system_test.go
+++ b/internal/provider/resource_infinity_snmp_network_management_system_test.go
@@ -82,7 +82,7 @@ func TestInfinitySnmpNetworkManagementSystem(t *testing.T) {
 
 func testInfinitySnmpNetworkManagementSystem(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_ssh_authorized_key_test.go
+++ b/internal/provider/resource_infinity_ssh_authorized_key_test.go
@@ -80,7 +80,7 @@ func TestInfinitySSHAuthorizedKey(t *testing.T) {
 
 func testInfinitySSHAuthorizedKey(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with min config
 			{

--- a/internal/provider/resource_infinity_ssh_password_hash_test.go
+++ b/internal/provider/resource_infinity_ssh_password_hash_test.go
@@ -28,7 +28,7 @@ func TestInfinitySSHPasswordHash(t *testing.T) {
 
 func testInfinitySSHPasswordHash(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: test.LoadTestFolder(t, "resource_infinity_ssh_password_hash_basic"),

--- a/internal/provider/resource_infinity_static_route_test.go
+++ b/internal/provider/resource_infinity_static_route_test.go
@@ -83,7 +83,7 @@ func TestInfinityStaticRoute(t *testing.T) {
 
 func testInfinityStaticRoute(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with min config
 			{

--- a/internal/provider/resource_infinity_stun_server_test.go
+++ b/internal/provider/resource_infinity_stun_server_test.go
@@ -88,7 +88,7 @@ func TestInfinityStunServer(t *testing.T) {
 
 func testInfinityStunServer(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_syslog_server_test.go
+++ b/internal/provider/resource_infinity_syslog_server_test.go
@@ -104,7 +104,7 @@ func TestInfinitySyslogServer(t *testing.T) {
 
 func testInfinitySyslogServer(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_system_location_test.go
+++ b/internal/provider/resource_infinity_system_location_test.go
@@ -1161,7 +1161,7 @@ func TestInfinitySystemLocation(t *testing.T) {
 
 func testInfinitySystemLocation(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: test.LoadTestFolder(t, "resource_infinity_system_location_full"),

--- a/internal/provider/resource_infinity_system_syncpoint_test.go
+++ b/internal/provider/resource_infinity_system_syncpoint_test.go
@@ -54,7 +54,7 @@ func TestInfinitySystemSyncpoint(t *testing.T) {
 
 func testInfinitySystemSyncpoint(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: test.LoadTestFolder(t, "resource_infinity_system_syncpoint_basic"),

--- a/internal/provider/resource_infinity_system_tuneable_test.go
+++ b/internal/provider/resource_infinity_system_tuneable_test.go
@@ -80,7 +80,7 @@ func TestInfinitySystemTuneable(t *testing.T) {
 
 func testInfinitySystemTuneable(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_teams_proxy_test.go
+++ b/internal/provider/resource_infinity_teams_proxy_test.go
@@ -128,7 +128,7 @@ func TestInfinityTeamsProxy(t *testing.T) {
 
 func testInfinityTeamsProxy(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: test.LoadTestFolder(t, "resource_infinity_teams_proxy_full"),

--- a/internal/provider/resource_infinity_tls_certificate_test.go
+++ b/internal/provider/resource_infinity_tls_certificate_test.go
@@ -84,7 +84,7 @@ func TestInfinityTLSCertificate(t *testing.T) {
 
 func testInfinityTLSCertificate(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"tls": {
 				Source: "hashicorp/tls",

--- a/internal/provider/resource_infinity_turn_server_test.go
+++ b/internal/provider/resource_infinity_turn_server_test.go
@@ -106,7 +106,7 @@ func TestInfinityTurnServer(t *testing.T) {
 
 func testInfinityTurnServer(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_upgrade_test.go
+++ b/internal/provider/resource_infinity_upgrade_test.go
@@ -40,7 +40,7 @@ func TestInfinityUpgrade(t *testing.T) {
 
 func testInfinityUpgrade(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: test.LoadTestFolder(t, "resource_infinity_upgrade_basic"),

--- a/internal/provider/resource_infinity_user_group_entity_mapping_test.go
+++ b/internal/provider/resource_infinity_user_group_entity_mapping_test.go
@@ -176,7 +176,7 @@ func TestInfinityUserGroupEntityMapping(t *testing.T) {
 
 func testInfinityUserGroupEntityMapping(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_user_group_test.go
+++ b/internal/provider/resource_infinity_user_group_test.go
@@ -110,7 +110,7 @@ func TestInfinityUserGroup(t *testing.T) {
 
 func testInfinityUserGroup(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_web_password_hash_test.go
+++ b/internal/provider/resource_infinity_web_password_hash_test.go
@@ -28,7 +28,7 @@ func TestInfinityWebPasswordHash(t *testing.T) {
 
 func testInfinityWebPasswordHash(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			{
 				Config: test.LoadTestFolder(t, "resource_infinity_web_password_hash_basic"),

--- a/internal/provider/resource_infinity_webapp_alias_test.go
+++ b/internal/provider/resource_infinity_webapp_alias_test.go
@@ -92,7 +92,7 @@ func TestInfinityWebappAlias(t *testing.T) {
 
 func testInfinityWebappAlias(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with full config
 			{

--- a/internal/provider/resource_infinity_webapp_branding_test.go
+++ b/internal/provider/resource_infinity_webapp_branding_test.go
@@ -84,7 +84,7 @@ func TestInfinityWebappBranding(t *testing.T) {
 
 func testInfinityWebappBranding(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		Steps: []resource.TestStep{
 			// Step 1: Create with min config
 			{

--- a/internal/provider/resource_infinity_worker_vm_test.go
+++ b/internal/provider/resource_infinity_worker_vm_test.go
@@ -325,7 +325,7 @@ func TestInfinityWorkerVM(t *testing.T) {
 
 func testInfinityWorkerVM(t *testing.T, client InfinityClient) {
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: getTestProtoV5ProviderFactories(client),
+		ProtoV6ProviderFactories: getTestProtoV6ProviderFactories(client),
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"tls": {
 				Source: "hashicorp/tls",


### PR DESCRIPTION
- Changed all instances of ProtoV5ProviderFactories to ProtoV6ProviderFactories across various resource integration and unit tests for the InfinityClient.
- This update ensures compatibility with the latest provider version and improves test reliability.
Closes #159 